### PR TITLE
Fix metadata for bugtracker

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -354,9 +354,11 @@ sub configure
           file      => [qw( bin/elf.PL )],
         },
         resources => {
-          license     => 'http://dev.perl.org/licenses/',
+          license     => [ 'http://dev.perl.org/licenses/' ],
           homepage    => 'http://search.cpan.org/~mhx/Convert-Binary-C/',
-          bugtracker  => 'http://rt.cpan.org/NoAuth/Bugs.html?Dist=Convert-Binary-C',
+          bugtracker  => {
+            web => 'http://rt.cpan.org/NoAuth/Bugs.html?Dist=Convert-Binary-C',
+          },
           MailingList => 'convert-binary-c@yahoogroups.com',
           repository  => {
             type => 'git',


### PR DESCRIPTION
In 0.78, You migrated to using meta-spec version 2 in Makefile.PL.

However, this had the subtle side effect of meaning the syntax you
declared the bug tracker with was no longer legal for meta version 2,
and got removed from the generated META.json

https://metacpan.org/diff/file?source=MHX/Convert-Binary-C-0.77&target=MHX/Convert-Binary-C-0.78#META.json

Its also worth noting you should probably return to shipping
with a recent ExtUtils::MakeMaker, not an old one.
