### PR TITLE
Remove use of indirect object notation (CPAN PRC)

### DIFF
--- a/autogen/compilers/compile.pl
+++ b/autogen/compilers/compile.pl
@@ -64,7 +64,7 @@ use vars qw(%config);
 
 do $OPT{cfgfile};
 
-my $c = new Convert::Binary::C %config;
+my $c = Convert::Binary::C->new(%config);
 
 $c->parse_file('test.h');
 
@@ -86,7 +86,7 @@ $init =~ s/(-?\d+)/
            "$1$suf";
          /ge;
 
-my $cc  = new Compiler::Config %OPT, ccflags => [@ARGV];
+my $cc  = Compiler::Config->new(%OPT, ccflags => [@ARGV]);
 # my $cfg = $cc->get_config;
 
 my $bin = $cc->_test_type($c->sourcify, 'test', $init, $c->sizeof('test'));
@@ -411,7 +411,7 @@ sub check_config
 
   $self->{debug} and import Convert::Binary::C debug => 'all';
 
-  my $c = eval { new Convert::Binary::C };
+  my $c = eval { Convert::Binary::C->new };
   $@ and return {code => ERR_CREATE};
 
   eval { $c->configure( %$config ) };
@@ -888,7 +888,7 @@ ENDC
   my $res = $self->_compile_temp;
   $res->{status} and return undef;
 
-  my $fh = new IO::File $self->{obj} or return undef;
+  my $fh = IO::File->new($self->{obj}) or return undef;
   binmode $fh;
 
   my $obj = do { local $/; <$fh> };
@@ -1977,7 +1977,7 @@ sub _names
     $files{$file} = 1;
     $ff = keys %files;
     $self->_work_in_progress( "$ff files found" );
-    my $fh = new IO::File $file;
+    my $fh = IO::File->new($file);
     next unless defined $fh;
     while( <$fh> ) {
       if( /^\s*#\s*include\s*[<"]([^>"]+)[>"]/ ) {
@@ -1999,7 +1999,7 @@ sub _names
     $fs++;
     $self->_work_in_progress( "($count) $fs/$ff files scanned" );
     -e $name or next;
-    my $fh = new IO::File $name;
+    my $fh = IO::File->new($name);
     next unless defined $fh;
     my $file = do { local $/; <$fh> };
     $file =~ s{\\\s*$/}{}g;
@@ -2240,7 +2240,7 @@ sub _temp
     unlink $self->{temp}
       or croak "Could not remove temporary file '$self->{temp}': $!\n";
   }
-  my $f = new IO::File ">$self->{temp}";
+  my $f = IO::File->new(">$self->{temp}");
   defined $f
     or croak "Could not open temporary file '$self->{temp}': $!\n";
   $f->print( @_ );

--- a/autogen/complex/footer.pl
+++ b/autogen/complex/footer.pl
@@ -152,14 +152,16 @@ sub checkrc
   }
 }
 
-my $p = new Convert::Binary::C ByteOrder   => 'LittleEndian',
-                               ShortSize   => 2,
-                               IntSize     => 4,
-                               LongSize    => 4,
-                               PointerSize => 4,
-                               FloatSize   => 4,
-                               DoubleSize  => 8,
-                               Alignment   => 4;
+my $p = Convert::Binary::C->new(
+    ByteOrder   => 'LittleEndian',
+    ShortSize   => 2,
+    IntSize     => 4,
+    LongSize    => 4,
+    PointerSize => 4,
+    FloatSize   => 4,
+    DoubleSize  => 8,
+    Alignment   => 4
+);
 
 $p->parse($types);
 

--- a/autogen/doc/Pod/Tree/MyHTML.pm
+++ b/autogen/doc/Pod/Tree/MyHTML.pm
@@ -61,7 +61,7 @@ sub _resolve_source
 
     isa $source, 'Pod::Tree' and return $source;
 
-    my $tree = new Pod::Tree;
+    my $tree = Pod::Tree->new;
     not $ref		    and $tree->load_file      ( $source);
     isa $source, 'IO::File' and $tree->load_fh	      ( $source);
     $ref eq 'SCALAR'        and $tree->load_string    ($$source);
@@ -80,11 +80,11 @@ sub _resolve_dest
     local *isa = \&UNIVERSAL::isa;
 
     isa $dest, 'HTML::Stream' and return 		  $dest;
-    ref $dest 		      and return new HTML::Stream $dest;
+    ref $dest 		      and return HTML::Stream->new($dest);
 
-    my $fh = new IO::File;
+    my $fh = IO::File->new;
     $fh->open(">$dest") or die "Pod::Tree::MyHTML::new: Can't open $dest: $!\n";
-    new HTML::Stream $fh
+    HTML::Stream->new($fh)
 }
 
 

--- a/autogen/doc/clone.pl
+++ b/autogen/doc/clone.pl
@@ -2,14 +2,14 @@ use Convert::Binary::C;
 
 #-8<-
 
-$c = new Convert::Binary::C Include => ['/usr/include'];
+$c = Convert::Binary::C->new(Include => ['/usr/include']);
 $c->parse_file('definitions.c');
 $clone = $c->clone;
 
 #-8<-
 
-$c = new Convert::Binary::C Include => ['/usr/include'];
+$c = Convert::Binary::C->new(Include => ['/usr/include']);
 $c->parse_file('definitions.c');
-$clone = new Convert::Binary::C %{$c->configure};
+$clone = Convert::Binary::C->new(%{$c->configure});
 $clone->parse($c->sourcify);
 

--- a/autogen/doc/compound.pl
+++ b/autogen/doc/compound.pl
@@ -2,7 +2,7 @@ use Convert::Binary::C;
 use Data::Dumper;
 $Data::Dumper::Indent = 1;
 
-$c = new Convert::Binary::C;
+$c = Convert::Binary::C->new;
 $c->parse_file('definitions.c');
 
 #-8<-

--- a/autogen/doc/compound_alignment.pl
+++ b/autogen/doc/compound_alignment.pl
@@ -2,7 +2,7 @@ use Convert::Binary::C;
 use Data::Dumper;
 $Data::Dumper::Indent = 0;
 
-$c = new Convert::Binary::C Alignment => 4, CompoundAlignment => 4;
+$c = Convert::Binary::C->new(Alignment => 4, CompoundAlignment => 4);
 
 #-8<-
 

--- a/autogen/doc/configure.pl
+++ b/autogen/doc/configure.pl
@@ -3,8 +3,10 @@ use Data::Dumper;
 use vars qw( $order ); #-8<-
 $Data::Dumper::Indent = 1; #-8<-
 
-$c = new Convert::Binary::C Define  => ['DEBUGGING', 'FOO=123'],
-                            Include => ['/usr/include'];
+$c = Convert::Binary::C->new(
+    Define  => [ 'DEBUGGING', 'FOO=123' ],
+    Include => ['/usr/include']
+);
 
 print Dumper($c->configure);
 
@@ -29,7 +31,7 @@ $c->Define(['foo', 'bar=123']);
 
 #-8<- 6
 
-$c = new Convert::Binary::C Include => ['/include'];
+$c = Convert::Binary::C->new(Include => ['/include']);
 $c->Include('/usr/include', '/usr/local/include');
 print Dumper($c->Include);
 

--- a/autogen/doc/enum.pl
+++ b/autogen/doc/enum.pl
@@ -2,7 +2,7 @@ use Convert::Binary::C;
 use Data::Dumper;
 $Data::Dumper::Indent = 1;
 
-$c = new Convert::Binary::C;
+$c = Convert::Binary::C->new;
 $c->parse_file('definitions.c');
 
 #-8<-

--- a/autogen/doc/enum_names.pl
+++ b/autogen/doc/enum_names.pl
@@ -2,7 +2,7 @@ use Convert::Binary::C;
 use Data::Dumper;
 $Data::Dumper::Indent = 0;
 
-$c = new Convert::Binary::C;
+$c = Convert::Binary::C->new;
 
 #-8<-
 

--- a/autogen/doc/hooks3.pl
+++ b/autogen/doc/hooks3.pl
@@ -218,7 +218,7 @@ $Data::Dumper::Indent = 1;
 
 use Config;
 
-$c = new Convert::Binary::C %CC, OrderMembers => 1;
+$c = Convert::Binary::C->new(%CC, OrderMembers => 1);
 $c->Include(["$Config{archlib}/CORE", @{$c->Include}]);
 $c->parse(<<ENDC);
 #include "EXTERN.h"

--- a/autogen/doc/intro.pl
+++ b/autogen/doc/intro.pl
@@ -6,7 +6,7 @@ $c = Convert::Binary::C->new;
 
 #-8<-
 
-$c = new Convert::Binary::C;
+$c = Convert::Binary::C->new;
 
 #-8<-
 
@@ -15,8 +15,8 @@ $c->configure(ByteOrder => 'LittleEndian',
 
 #-8<-
 
-$c = new Convert::Binary::C ByteOrder => 'LittleEndian',
-                            Alignment => 2;
+$c = Convert::Binary::C->new(ByteOrder => 'LittleEndian',
+                             Alignment => 2);
 
 #-8<-
 

--- a/autogen/doc/keywords.pl
+++ b/autogen/doc/keywords.pl
@@ -11,7 +11,7 @@ while (<FILE>) {
 
 close FILE;
 
-my $c = new Convert::Binary::C;
+my $c = Convert::Binary::C->new;
 my @kw;
 
 for my $k (sort keys %h) {

--- a/autogen/doc/parse_file.pl
+++ b/autogen/doc/parse_file.pl
@@ -1,6 +1,6 @@
 use Convert::Binary::C;
 
-$c = new Convert::Binary::C;
+$c = Convert::Binary::C->new;
 
 #-8<-
 $c->parse(<<'#-8<-');

--- a/autogen/doc/pdf/Pod/MyLaTeX.pm
+++ b/autogen/doc/pdf/Pod/MyLaTeX.pm
@@ -1117,7 +1117,7 @@ sub interior_sequence {
 
   } elsif ($seq_command eq 'L') {
 
-    my $link = new Pod::Hyperlink($seq_argument);
+    my $link = Pod::Hyperlink->new($seq_argument);
 
     # undef on failure
     unless (defined $link) {
@@ -1161,7 +1161,7 @@ sub interior_sequence {
   } elsif ($seq_command eq 'P') {
     print "[$seq_argument]\n";
     if( exists $self->{KnownPODs}{$seq_argument} ) {
-      my $link = new Pod::Hyperlink($seq_argument);
+      my $link = Pod::Hyperlink->new($seq_argument);
 
       # undef on failure
       unless (defined $link) {
@@ -1232,7 +1232,7 @@ sub begin_list {
 
   # Indicate that a list should be started for the next item
   # need to do this to work out the type of list
-  push ( @{$self->lists}, new Pod::List(-indent => $indent, 
+  push ( @{$self->lists}, Pod::List->new(-indent => $indent, 
 					-start => $line_num,
 					-file => $self->input_file,
 				       )	 

--- a/autogen/doc/pdf/Pod/ParseUtils.pm
+++ b/autogen/doc/pdf/Pod/ParseUtils.pm
@@ -21,7 +21,7 @@ Pod::ParseUtils - helpers for POD parsing and conversion
 
   use Pod::ParseUtils;
 
-  my $list = new Pod::List;
+  my $list = Pod::List->new;
   my $link = Pod::Hyperlink->new('Pod::Parser');
 
 =head1 DESCRIPTION

--- a/autogen/doc/preprocessor.pl
+++ b/autogen/doc/preprocessor.pl
@@ -1,5 +1,5 @@
 use Convert::Binary::C;
-$c = new Convert::Binary::C Alignment => 4;
+$c = Convert::Binary::C->new(Alignment => 4);
 
 #-8<-
 

--- a/autogen/doc/reconfig.pl
+++ b/autogen/doc/reconfig.pl
@@ -1,6 +1,6 @@
 use Convert::Binary::C;
 
-$c = new Convert::Binary::C Alignment => 4, IntSize => 4;
+$c = Convert::Binary::C->new(Alignment => 4, IntSize => 4);
 
 #-8<-
 $c->parse(<<'#-8<-');

--- a/autogen/doc/sourcify.pl
+++ b/autogen/doc/sourcify.pl
@@ -1,6 +1,6 @@
 use Convert::Binary::C;
 
-$c = new Convert::Binary::C;
+$c = Convert::Binary::C->new;
 $c->parse(<<'END');
 
 #define ADD(a, b) ((a) + (b))

--- a/autogen/doc/synopsis_advanced.pl
+++ b/autogen/doc/synopsis_advanced.pl
@@ -4,7 +4,7 @@ use Data::Dumper;
 #---------------------
 # Create a new object
 #---------------------
-my $c = new Convert::Binary::C ByteOrder => 'BigEndian';
+my $c = Convert::Binary::C->(ByteOrder => 'BigEndian');
 
 #---------------------------------------------------
 # Add include paths and global preprocessor defines

--- a/autogen/doc/types.pl
+++ b/autogen/doc/types.pl
@@ -7,7 +7,7 @@ struct foo {
 typedef int foo;
 #-8<-
 
-$c = new Convert::Binary::C;
+$c = Convert::Binary::C->new;
 $size = $c->sizeof('unsigned long');
 $data = $c->pack('short int', 42);
 

--- a/autogen/ppsym/ppsym.pl
+++ b/autogen/ppsym/ppsym.pl
@@ -71,7 +71,7 @@ exit 0;
 sub getsym
 {
   /\.h$/ or return;
-  my $fh = new IO::File $_ or return;
+  my $fh = IO::File->($_) or return;
   my $file = do { local $/; <$fh> };
   my $id = '[a-zA-Z_]\w*';
 

--- a/autogen/sizes/mkoffsets.pl
+++ b/autogen/sizes/mkoffsets.pl
@@ -5,7 +5,7 @@ use strict;
 my $cfg = require '../../tests/include/config.pl';
 s!^tests!../../tests! for @{$cfg->{Include}};
 
-my $c = new Convert::Binary::C %$cfg;
+my $c = Convert::Binary::C->new(%$cfg);
 
 $c->parse_file( '../../tests/include/include.c' );
 

--- a/autogen/sizes/mksizes.pl
+++ b/autogen/sizes/mksizes.pl
@@ -5,7 +5,7 @@ use strict;
 my $cfg = require '../../tests/include/config.pl';
 s!^tests!../../tests! for @{$cfg->{Include}};
 
-my $c = new Convert::Binary::C %$cfg;
+my $c = Convert::Binary::C->new(%$cfg);
 
 $c->parse_file( '../../tests/include/include.c' );
 

--- a/devel/bench.pl
+++ b/devel/bench.pl
@@ -44,7 +44,7 @@ my %config = (
   Include      => ['tests/include/perlinc', 'tests/include/include'],
 );
 
-my $c = new Convert::Binary::C;
+my $c = Convert::Binary::C->new;
 
 for my $k (keys %config) {
   eval { $c->configure($k => $config{$k}) };

--- a/devel/test.pl
+++ b/devel/test.pl
@@ -6,11 +6,13 @@ use Devel::Peek;
 
 my $code = do { local $/; <DATA> };
 
-my $p = new Convert::Binary::C ByteOrder   => 'BigEndian',
-                               IntSize     => 4,
-                               PointerSize => 4,
-                               EnumSize    => 0,
-                               Alignment   => 4;
+my $p = Convert::Binary::C->new(
+    ByteOrder   => 'BigEndian',
+    IntSize     => 4,
+    PointerSize => 4,
+    EnumSize    => 0,
+    Alignment   => 4
+);
 
 $p->parse( $code );
 

--- a/devel/test2.pl
+++ b/devel/test2.pl
@@ -6,12 +6,14 @@ use Devel::Peek;
 
 my $code = do { local $/; <DATA> };
 
-my $p = new Convert::Binary::C ByteOrder   => 'BigEndian',
-                               IntSize     => 4,
-                               PointerSize => 4,
-                               EnumSize    => 0,
-                               Warnings    => 1,
-                               Alignment   => 4;
+my $p = Convert::Binary::C->new(
+    ByteOrder   => 'BigEndian',
+    IntSize     => 4,
+    PointerSize => 4,
+    EnumSize    => 0,
+    Warnings    => 1,
+    Alignment   => 4
+);
 
 $p->parse( $code );
 

--- a/devel/test3.pl
+++ b/devel/test3.pl
@@ -8,7 +8,7 @@ my @inc = qw(
   /usr/include
 );
 
-my $p = new Convert::Binary::C Include => [@inc];
+my $p = Convert::Binary::C->new(Include => [@inc]);
 
 $p->parse( <<'ENDC' );
 #include <stdio.h>

--- a/devel/test5.pl
+++ b/devel/test5.pl
@@ -6,7 +6,7 @@ use Data::Dumper;
 
 my $code = do { local $/; <DATA> };
 
-my $p = new Convert::Binary::C;
+my $p = Convert::Binary::C->new;
 $p->parse( $code );
 
 print Data::Dumper->Dump( [[$p->enum],[$p->struct],[$p->typedef]],

--- a/devel/testdrive.pl
+++ b/devel/testdrive.pl
@@ -85,10 +85,10 @@ $OPT{upload} and upload_file( $hosts[0], $file );
 $OPT{remove} and remove_reports( $hosts[0] );
 
 if ($OPT{compile}) {
-  my @t = map { new threads
+  my @t = map { threads->new(
    \&test_compile, $_, $file
   # \&version, $_
-  } @hosts;
+  ) } @hosts;
   
   $_->join for @t;
 }
@@ -161,7 +161,7 @@ $perl -v
 $perl -V
 END
 
-  my $f = new IO::File;
+  my $f = IO::File->new;
   $f->open( ">version-$host->{ip}.log" );
   $f->print( @lines );
   $f->close;
@@ -203,7 +203,7 @@ cd ..
 rm -rf $dist
 END
 
-  my $f = new IO::File;
+  my $f = IO::File->new;
   $f->open( ">testdrive-$host->{ip}.log" );
   $f->print( @lines );
   $f->close;

--- a/lib/Convert/Binary/C.pm
+++ b/lib/Convert/Binary/C.pm
@@ -103,7 +103,7 @@ Convert::Binary::C - Binary Data Conversion using C Types
   #---------------------
   # Create a new object
   #---------------------
-  my $c = new Convert::Binary::C ByteOrder => 'BigEndian';
+  my $c = Convert::Binary::C->new(ByteOrder => 'BigEndian');
   
   #---------------------------------------------------
   # Add include paths and global preprocessor defines
@@ -349,8 +349,8 @@ and alignment, you can use
 
 or you can change the construction code to
 
-  $c = new Convert::Binary::C ByteOrder => 'LittleEndian',
-                              Alignment => 2;
+  $c = Convert::Binary::C->new(ByteOrder => 'LittleEndian',
+                               Alignment => 2);
 
 Either way, the object will now know that it should use
 little endian (Intel) byte order and 2-byte struct member
@@ -606,7 +606,7 @@ Basic types, or atomic types, are C<int> or C<char>, for example.
 It's possible to use these basic types without having parsed any
 code. You can simply do
 
-  $c = new Convert::Binary::C;
+  $c = Convert::Binary::C->new;
   $size = $c->sizeof('unsigned long');
   $data = $c->pack('short int', 42);
 
@@ -1450,7 +1450,7 @@ the perl internals using hooks.
 
   use Config;
   
-  $c = new Convert::Binary::C %CC, OrderMembers => 1;
+  $c = Convert::Binary::C->new(%CC, OrderMembers => 1);
   $c->Include(["$Config{archlib}/CORE", @{$c->Include}]);
   $c->parse(<<ENDC);
   #include "EXTERN.h"
@@ -1604,7 +1604,7 @@ wins.
 The constructor is used to create a new Convert::Binary::C object.
 You can simply use
 
-  $c = new Convert::Binary::C;
+  $c = Convert::Binary::C->new;
 
 without additional arguments to create an object, or you can
 optionally pass any arguments to the constructor that are
@@ -1649,8 +1649,8 @@ used with the L<Data::Dumper|Data::Dumper> module, for example:
   use Convert::Binary::C;
   use Data::Dumper;
   
-  $c = new Convert::Binary::C Define  => ['DEBUGGING', 'FOO=123'],
-                              Include => ['/usr/include'];
+  $c = Convert::Binary::C->new(Define  => ['DEBUGGING', 'FOO=123'],
+                               Include => ['/usr/include']);
   
   print Dumper($c->configure);
 
@@ -1719,7 +1719,7 @@ But if you pass a list of strings instead of an array reference
 (which cannot be done when using L<C<configure>|/"configure">),
 the new list items are B<appended> to the current list, so
 
-  $c = new Convert::Binary::C Include => ['/include'];
+  $c = Convert::Binary::C->new(Include => ['/include']);
   $c->Include('/usr/include', '/usr/local/include');
   print Dumper($c->Include);
   
@@ -2616,7 +2616,7 @@ The L<C<clean>|/"clean"> method returns a reference to its object.
 
 Makes the object return an exact independent copy of itself.
 
-  $c = new Convert::Binary::C Include => ['/usr/include'];
+  $c = Convert::Binary::C->new(Include => ['/usr/include']);
   $c->parse_file('definitions.c');
   $clone = $c->clone;
 
@@ -2626,9 +2626,9 @@ the order of the parsed data, which would make methods such
 as L<C<compound>|/"compound"> return the definitions in a different
 order.) to:
 
-  $c = new Convert::Binary::C Include => ['/usr/include'];
+  $c = Convert::Binary::C->new(Include => ['/usr/include']);
   $c->parse_file('definitions.c');
-  $clone = new Convert::Binary::C %{$c->configure};
+  $clone = Convert::Binary::C->new(%{$c->configure});
   $clone->parse($c->sourcify);
 
 Using L<C<clone>|/"clone"> is just a lot faster.
@@ -3945,7 +3945,7 @@ represent all parsed C data structures.
 
   use Convert::Binary::C;
   
-  $c = new Convert::Binary::C;
+  $c = Convert::Binary::C->new;
   $c->parse(<<'END');
   
   #define ADD(a, b) ((a) + (b))

--- a/lib/Convert/Binary/C/Cached.pm
+++ b/lib/Convert/Binary/C/Cached.pm
@@ -227,7 +227,7 @@ sub __parse
 sub __can_use_cache
 {
   my $self = shift;
-  my $fh = new IO::File;
+  my $fh = IO::File->new;
 
   unless (-e $self->{cache} and -s _) {
     $ENV{CBCC_DEBUG} and print STDERR "CBCC: cache file '$self->{cache}' doesn't exist or is empty\n";
@@ -304,7 +304,7 @@ sub __can_use_cache
 sub __save_cache
 {
   my $self = shift;
-  my $fh = new IO::File;
+  my $fh = IO::File->new;
 
   $fh->open(">$self->{cache}") or croak "Cannot open '$self->{cache}': $!";
 

--- a/support/Test/Harness.pm
+++ b/support/Test/Harness.pm
@@ -316,7 +316,7 @@ sub execute_tests {
 
     my @dir_files;
     @dir_files = _globdir $Files_In_Dir if defined $Files_In_Dir;
-    my $run_start_time = new Benchmark;
+    my $run_start_time = Benchmark->new;
 
     my $width = _leader_width(@tests);
     foreach my $tfile (@tests) {
@@ -483,7 +483,7 @@ sub execute_tests {
             }
         }
     } # foreach test
-    $tot{bench} = timediff(new Benchmark, $run_start_time);
+    $tot{bench} = timediff(Benchmark->new, $run_start_time);
 
     $Strap->_restore_PERL5LIB;
 

--- a/support/Test/Harness/Point.pm
+++ b/support/Test/Harness/Point.pm
@@ -17,7 +17,7 @@ One Test::Harness::Point object represents a single test point.
 
 =head2 new()
 
-    my $point = new Test::Harness::Point;
+    my $point = Test::Harness::Point->new;
 
 Create a test point object.
 

--- a/support/Test/More.pm
+++ b/support/Test/More.pm
@@ -965,7 +965,7 @@ the easiest way to illustrate:
 
         skip "HTML::Lint not installed", 2 if $@;
 
-        my $lint = new HTML::Lint;
+        my $lint = HTML::Lint->new;
         isa_ok( $lint, "HTML::Lint" );
 
         $lint->parse( $html );

--- a/token/pragma.pl
+++ b/token/pragma.pl
@@ -16,8 +16,8 @@
 
 use Devel::Tokenizer::C;
 
-$t = new Devel::Tokenizer::C TokenFunc => \&tok_code,
-                             TokenEnd  => 'PRAGMA_TOKEN_END';
+$t = Devel::Tokenizer::C->new(TokenFunc => \&tok_code,
+                              TokenEnd  => 'PRAGMA_TOKEN_END');
 
 $t->add_tokens( qw(
   pack

--- a/util/t/maketests.pl
+++ b/util/t/maketests.pl
@@ -3,7 +3,7 @@ use IO::File;
 while (<DATA>) {
   /\S/ or next;
   my $file = sprintf "t/%03d.t", ++$i;
-  my $f = new IO::File ">$file" or die "$file: $!\n";
+  my $f = IO::File->new(">$file") or die "$file: $!\n";
   print $f <<END
 require 't/test_memalloc.pl';
 $_

--- a/util/t/test_memalloc.pl
+++ b/util/t/test_memalloc.pl
@@ -132,7 +132,7 @@ sub test {
 }
 
 sub slurp {
-  my $file = new IO::File $_[0] or die "$_[0]: $!\n";
+  my $file = IO::File->new($_[0]) or die "$_[0]: $!\n";
   <$file>;
 }
 


### PR DESCRIPTION
This change replaces uses of indirect object notation, changing
```
new Foo @args
```
to
```
Foo->new(@args)
```