### PR TITLE
indirect object syntax

### DIFF
--- a/TODO
+++ b/TODO
@@ -354,7 +354,7 @@ for future releases (in no special order):
 
   - for example:
 
-      $p = new Convert::Binary::C;
+      $p = Convert::Binary::C->new;
       $p->parse_file( 'some_code.h' );
       $type = $p->get_type( 'type' );
       $data = $type->unpack( $raw );

--- a/bin/ccconfig
+++ b/bin/ccconfig
@@ -63,7 +63,7 @@ $OPT{quiet} or print STDERR $MESSAGE, "\n";
 my $output = \*STDOUT;
 
 if (exists $OPT{'output-file'}) {
-  $output = new IO::File ">$OPT{'output-file'}"
+  $output = IO::File->new(">$OPT{'output-file'}")
             or die "Cannot open $OPT{'output-file'}: $!\n";
 }
 
@@ -91,7 +91,7 @@ Valid output formats are: $valid
 EOM
 }
 
-my $cc  = new Compiler::Config %OPT, ccflags => [@ARGV];
+my $cc  = Compiler::Config->new(%OPT, ccflags => [@ARGV]);
 my $cfg = $cc->get_config;
 $cc->cleanup;
 
@@ -866,7 +866,7 @@ ENDC
   my $res = $self->_compile_temp;
   $res->{status} and return undef;
 
-  my $fh = new IO::File $self->_objfile or return undef;
+  my $fh = IO::File->new($self->_objfile) or return undef;
   binmode $fh;
 
   my $obj = do { local $/; <$fh> };
@@ -1957,7 +1957,7 @@ sub _names
     $files{$file} = 1;
     $ff = keys %files;
     $self->_work_in_progress( "$ff files found" );
-    my $fh = new IO::File $file;
+    my $fh = IO::File->new($file);
     next unless defined $fh;
     while( <$fh> ) {
       if( /^\s*#\s*include\s*[<"]([^>"]+)[>"]/ ) {
@@ -1979,7 +1979,7 @@ sub _names
     $fs++;
     $self->_work_in_progress( "($count) $fs/$ff files scanned" );
     -e $name or next;
-    my $fh = new IO::File $name;
+    my $fh = IO::File->new($name);
     next unless defined $fh;
     my $file = do { local $/; <$fh> };
     $file =~ s{\\\s*$/}{}g;
@@ -2334,7 +2334,7 @@ sub _read_pp
     return @{$res->{stdout}};
   }
 
-  my $f = new IO::File $self->_ppfile or return;
+  my $f = IO::File->new($self->_ppfile) or return;
 
   return <$f>;
 }
@@ -2348,7 +2348,7 @@ sub _temp
     unlink $temp
         or croak "Could not remove temporary file '$temp': $!\n";
   }
-  my $f = new IO::File ">$temp"
+  my $f = IO::File->new(">$temp")
       or croak "Could not open temporary file '$temp': $!\n";
   $f->print(@_);
 }

--- a/bin/perltypes.PL
+++ b/bin/perltypes.PL
@@ -35,7 +35,7 @@ MSG
 #-------------------------------------
 
 my $cfg = require "$base/config.pl";
-my $c = new Convert::Binary::C %$cfg;
+my $c = Convert::Binary::C->new(%$cfg);
 
 #------------------
 # Parse the C file.

--- a/lib/Convert/Binary/C.pm
+++ b/lib/Convert/Binary/C.pm
@@ -103,7 +103,7 @@ Convert::Binary::C - Binary Data Conversion using C Types
   #---------------------
   # Create a new object
   #---------------------
-  my $c = new Convert::Binary::C ByteOrder => 'BigEndian';
+  my $c = Convert::Binary::C->new(ByteOrder => 'BigEndian');
   
   #---------------------------------------------------
   # Add include paths and global preprocessor defines
@@ -326,13 +326,9 @@ to load the module. Its interface is completely object
 oriented, so it doesn't export any functions.
 
 Next, you need to create a new Convert::Binary::C object. This
-can be done by either
+can be done via
 
   $c = Convert::Binary::C->new;
-
-or
-
-  $c = new Convert::Binary::C;
 
 You can optionally pass configuration options to
 the L<constructor|/"new"> as described in the next section.
@@ -349,8 +345,8 @@ and alignment, you can use
 
 or you can change the construction code to
 
-  $c = new Convert::Binary::C ByteOrder => 'LittleEndian',
-                              Alignment => 2;
+  $c = Convert::Binary::C->new(ByteOrder => 'LittleEndian',
+                              Alignment => 2);
 
 Either way, the object will now know that it should use
 little endian (Intel) byte order and 2-byte struct member
@@ -606,7 +602,7 @@ Basic types, or atomic types, are C<int> or C<char>, for example.
 It's possible to use these basic types without having parsed any
 code. You can simply do
 
-  $c = new Convert::Binary::C;
+  $c = Convert::Binary::C->new;
   $size = $c->sizeof('unsigned long');
   $data = $c->pack('short int', 42);
 
@@ -1450,7 +1446,7 @@ the perl internals using hooks.
 
   use Config;
   
-  $c = new Convert::Binary::C %CC, OrderMembers => 1;
+  $c = Convert::Binary::C->new(%CC, OrderMembers => 1);
   $c->Include(["$Config{archlib}/CORE", @{$c->Include}]);
   $c->parse(<<ENDC);
   #include "EXTERN.h"
@@ -1604,7 +1600,7 @@ wins.
 The constructor is used to create a new Convert::Binary::C object.
 You can simply use
 
-  $c = new Convert::Binary::C;
+  $c = Convert::Binary::C->new;
 
 without additional arguments to create an object, or you can
 optionally pass any arguments to the constructor that are
@@ -1649,8 +1645,8 @@ used with the L<Data::Dumper|Data::Dumper> module, for example:
   use Convert::Binary::C;
   use Data::Dumper;
   
-  $c = new Convert::Binary::C Define  => ['DEBUGGING', 'FOO=123'],
-                              Include => ['/usr/include'];
+  $c = Convert::Binary::C->new(Define  => ['DEBUGGING', 'FOO=123'],
+                              Include => ['/usr/include']);
   
   print Dumper($c->configure);
 
@@ -1719,7 +1715,7 @@ But if you pass a list of strings instead of an array reference
 (which cannot be done when using L<C<configure>|/"configure">),
 the new list items are B<appended> to the current list, so
 
-  $c = new Convert::Binary::C Include => ['/include'];
+  $c = Convert::Binary::C->new(Include => ['/include']);
   $c->Include('/usr/include', '/usr/local/include');
   print Dumper($c->Include);
   
@@ -2616,7 +2612,7 @@ The L<C<clean>|/"clean"> method returns a reference to its object.
 
 Makes the object return an exact independent copy of itself.
 
-  $c = new Convert::Binary::C Include => ['/usr/include'];
+  $c = Convert::Binary::C->new(Include => ['/usr/include']);
   $c->parse_file('definitions.c');
   $clone = $c->clone;
 
@@ -2626,9 +2622,9 @@ the order of the parsed data, which would make methods such
 as L<C<compound>|/"compound"> return the definitions in a different
 order.) to:
 
-  $c = new Convert::Binary::C Include => ['/usr/include'];
+  $c = Convert::Binary::C->new(Include => ['/usr/include']);
   $c->parse_file('definitions.c');
-  $clone = new Convert::Binary::C %{$c->configure};
+  $clone = Convert::Binary::C->new(%{$c->configure});
   $clone->parse($c->sourcify);
 
 Using L<C<clone>|/"clone"> is just a lot faster.
@@ -3945,7 +3941,7 @@ represent all parsed C data structures.
 
   use Convert::Binary::C;
   
-  $c = new Convert::Binary::C;
+  $c = Convert::Binary::C->new;
   $c->parse(<<'END');
   
   #define ADD(a, b) ((a) + (b))

--- a/lib/Convert/Binary/C/Cached.pm
+++ b/lib/Convert/Binary/C/Cached.pm
@@ -227,7 +227,7 @@ sub __parse
 sub __can_use_cache
 {
   my $self = shift;
-  my $fh = new IO::File;
+  my $fh = IO::File->new;
 
   unless (-e $self->{cache} and -s _) {
     $ENV{CBCC_DEBUG} and print STDERR "CBCC: cache file '$self->{cache}' doesn't exist or is empty\n";
@@ -304,7 +304,7 @@ sub __can_use_cache
 sub __save_cache
 {
   my $self = shift;
-  my $fh = new IO::File;
+  my $fh = IO::File->new;
 
   $fh->open(">$self->{cache}") or croak "Cannot open '$self->{cache}': $!";
 

--- a/tests/001_init.t
+++ b/tests/001_init.t
@@ -20,12 +20,12 @@ require_ok('Convert::Binary::C::Cached');
 #===================================================================
 # check if we build the right object (4 tests)
 #===================================================================
-eval { $p = new Convert::Binary::C };
+eval { $p = Convert::Binary::C->new };
 is($@, '', "create Convert::Binary::C object");
 is(ref $p, 'Convert::Binary::C',
    "blessed Convert::Binary::C reference");
 
-eval { $p = new Convert::Binary::C::Cached };
+eval { $p = Convert::Binary::C::Cached->new };
 is($@, '', "create Convert::Binary::C::Cached object");
 is(ref $p, 'Convert::Binary::C::Cached',
    "blessed Convert::Binary::C::Cached reference");
@@ -34,12 +34,14 @@ is(ref $p, 'Convert::Binary::C::Cached',
 # check initialization during construction (4 tests)
 #===================================================================
 eval {
-  $p = new Convert::Binary::C PointerSize => 4,
-                              EnumSize    => 4,
-                              IntSize     => 4,
-                              Alignment   => 2,
-                              ByteOrder   => 'BigEndian',
-                              EnumType    => 'Both';
+  $p = Convert::Binary::C->new(
+    PointerSize => 4,
+    EnumSize    => 4,
+    IntSize     => 4,
+    Alignment   => 2,
+    ByteOrder   => 'BigEndian',
+    EnumType    => 'Both',
+  );
 };
 is($@, '', "create Convert::Binary::C object with arguments");
 is(ref $p, 'Convert::Binary::C',
@@ -48,13 +50,15 @@ is(ref $p, 'Convert::Binary::C',
 @warn = ();
 eval {
   local $SIG{__WARN__} = sub { push @warn, $_[0] };
-  $p = new Convert::Binary::C::Cached Cache       => 'tests/cache.cbc',
-                                      PointerSize => 4,
-                                      EnumSize    => 4,
-                                      IntSize     => 4,
-                                      Alignment   => 2,
-                                      ByteOrder   => 'BigEndian',
-                                      EnumType    => 'Both';
+  $p = Convert::Binary::C::Cached->new(
+    Cache       => 'tests/cache.cbc',
+    PointerSize => 4,
+    EnumSize    => 4,
+    IntSize     => 4,
+    Alignment   => 2,
+    ByteOrder   => 'BigEndian',
+    EnumType    => 'Both',
+  );
 };
 is($@, '', "create Convert::Binary::C::Cached object with arguments");
 is(ref $p, 'Convert::Binary::C::Cached',
@@ -76,12 +80,12 @@ else { pass('warnings') }
 # check unknown options in constructor (2 tests)
 #===================================================================
 eval {
-  $p = new Convert::Binary::C FOO => 123, ByteOrder => 'BigEndian', BAR => ['abc'];
+  $p = Convert::Binary::C->new(FOO => 123, ByteOrder => 'BigEndian', BAR => ['abc']);
 };
 like($@, qr/Invalid option 'FOO' at \Q$0/);
 
 eval {
-  $p = new Convert::Binary::C::Cached FOO => 123, ByteOrder => 'BigEndian', BAR => ['abc'];
+  $p = Convert::Binary::C::Cached->new(FOO => 123, ByteOrder => 'BigEndian', BAR => ['abc']);
 };
 like($@, qr/Invalid option 'FOO' at \Q$0/);
 
@@ -89,12 +93,12 @@ like($@, qr/Invalid option 'FOO' at \Q$0/);
 # check invalid construction (2 tests)
 #===================================================================
 eval {
-  $p = new Convert::Binary::C FOO;
+  $p = Convert::Binary::C->new(FOO);
 };
 like($@, qr/Number of configuration arguments to new must be even at \Q$0/);
 
 eval {
-  $p = new Convert::Binary::C::Cached FOO;
+  $p = Convert::Binary::C::Cached->new(FOO);
 };
 like($@, qr/Number of configuration arguments to new must be even at \Q$0/);
 
@@ -102,12 +106,12 @@ like($@, qr/Number of configuration arguments to new must be even at \Q$0/);
 # check invalid construction (2 tests)
 #===================================================================
 eval {
-  $p = new Convert::Binary::C ByteOrder => 'FOO';
+  $p = Convert::Binary::C->new(ByteOrder => 'FOO');
 };
 like($@, qr/ByteOrder must be.*not 'FOO' at \Q$0/);
 
 eval {
-  $p = new Convert::Binary::C::Cached ByteOrder => 'FOO';
+  $p = Convert::Binary::C::Cached->new(ByteOrder => 'FOO');
 };
 like($@, qr/ByteOrder must be.*not 'FOO' at \Q$0/);
 
@@ -124,7 +128,7 @@ ok(not defined $p);
 # check calling feature as method (2 tests)
 #===================================================================
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p = $p->feature('debug');
 };
 is($@, '');

--- a/tests/101_basic.t
+++ b/tests/101_basic.t
@@ -48,14 +48,16 @@ print "1..211\n";
 #===================================================================
 
 eval {
-  $p = new Convert::Binary::C PointerSize => 4,
-                              EnumSize    => 4,
-                              IntSize     => 4,
-                              LongSize    => 4,
-                              Alignment   => 2,
-                              ByteOrder   => 'BigEndian',
-                              EnumType    => 'String';
-  $q = new Convert::Binary::C;
+  $p = Convert::Binary::C->new(
+    PointerSize => 4,
+    EnumSize    => 4,
+    IntSize     => 4,
+    LongSize    => 4,
+    Alignment   => 2,
+    ByteOrder   => 'BigEndian',
+    EnumType    => 'String',
+  );
+  $q = Convert::Binary::C->new;
 };
 ok($@,'');
 
@@ -285,7 +287,7 @@ reccmp( $refres, $result );
 # test pack/unpack/sizeof/typeof for basic types
 #------------------------------------------------
 
-$p = new Convert::Binary::C;
+$p = Convert::Binary::C->new;
 
 @tests = (
   ['char',        $p->CharSize      ],

--- a/tests/201_config.t
+++ b/tests/201_config.t
@@ -48,7 +48,7 @@ sub check_config
 
       my $reference = $config->{out} || $config->{in};
 
-      eval { $p = new Convert::Binary::C };
+      eval { $p = Convert::Binary::C->new };
       skip($reason, $@, '', "failed to create Convert::Binary::C object");
 
       print "# \$p->configure( $option => $config->{in} )\n";
@@ -159,7 +159,7 @@ sub check_option_strlist
   for my $config ( @tests ) {
     @warn = ();
 
-    eval { $p = new Convert::Binary::C };
+    eval { $p = Convert::Binary::C->new };
     ok($@, '', "failed to create Convert::Binary::C object");
 
     print "# \$p->configure( $option => $config->{in} )\n";
@@ -223,7 +223,7 @@ sub check_option_strlist_args {
   my $option = shift;
   my @warn;
   eval {
-    $p = new Convert::Binary::C;
+    $p = Convert::Binary::C->new;
     $p->$option( [qw(foo bar)] );
     $p->$option( 'include' );
     $p->$option( qw(a b c) );
@@ -433,19 +433,19 @@ check_option_strlist_args( $_ ) for qw( Include
 #===================================================================
 
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p->configure( DisabledKeywords => ['void', 'foo', 'const'] );
 };
 ok( $@, qr/Cannot disable unknown keyword 'foo'.*$thisfile/ );
 
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p->DisabledKeywords( 'void', 'foo', 'const' );
 };
 ok( $@, qr/DisabledKeywords cannot take more than one argument.*$thisfile/ );
 
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p->DisabledKeywords( ['auto', 'enum'] );
   $p->DisabledKeywords( ['void', 'while', 'register'] );
 };
@@ -458,43 +458,43 @@ ok( "@$kw", "auto enum", 'DisabledKeywords did not preserve configuration' );
 #===================================================================
 
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p->configure( KeywordMap => 5 );
 };
 ok( $@, qr/KeywordMap wants a hash reference.*$thisfile/ );
 
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p->configure( KeywordMap => [ __xxx__ => 'foo' ] );
 };
 ok( $@, qr/KeywordMap wants a hash reference.*$thisfile/ );
 
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p->KeywordMap( { '' => 'int' } );
 };
 ok( $@, qr/Cannot use empty string as a keyword.*$thisfile/ );
 
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p->KeywordMap( { '1_d' => 'int' } );
 };
 ok( $@, qr/Cannot use '1_d' as a keyword.*$thisfile/ );
 
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p->KeywordMap( { '_d' => [] } );
 };
 ok( $@, qr/Cannot use a reference as a keyword.*$thisfile/ );
 
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p->KeywordMap( { '_d' => 'foo' } );
 };
 ok( $@, qr/Cannot use 'foo' as a keyword.*$thisfile/ );
 
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p->KeywordMap( {'__const' => 'const', '__restrict' => undef} );
   $p->KeywordMap( {'__volatile' => 'volatile', '__foo' => 'foo'} );
 };
@@ -512,7 +512,7 @@ ok( "@{[sort keys %$kw]}", "__const __restrict", 'KeywordMap did not preserve co
 foreach $config ( @tests )
 {
   eval {
-    $p = new Convert::Binary::C;
+    $p = Convert::Binary::C->new;
     $p->configure( @{$config->{value}} );
   };
   ok( ($@ eq '' ? SUCCEED : FAIL), $config->{result},
@@ -524,7 +524,7 @@ foreach $config ( @tests )
 # check invalid option
 #===================================================================
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p->configure(
     Something => 'xxx',
     ByteOrder => 'BigEndian',
@@ -537,7 +537,7 @@ ok( $@, qr/Invalid option 'Something'.*$thisfile/ );
 # check invalid method
 #===================================================================
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p->some_method( 1, 2, 3 );
 };
 ok( $@, qr/Invalid method some_method called.*$thisfile/ );
@@ -578,7 +578,7 @@ ok( $@, qr/Invalid method some_method called.*$thisfile/ );
 );
 
 eval {
-  $p = new Convert::Binary::C %config;
+  $p = Convert::Binary::C->new(%config);
   $cfg = $p->configure;
 };
 ok( $@, '', "failed to retrieve configuration" );
@@ -625,7 +625,7 @@ ok( compare_config( \%config, $cfg ) );
 eval {
   local $SIG{__WARN__} = sub { push @warn, shift };
 
-  $p = new Convert::Binary::C %config;
+  $p = Convert::Binary::C->new(%config);
 
   $p->UnsignedChars( 1 )->configure( ShortSize => 4, EnumType => 'Both', EnumSize => 0 )
     ->Include( ['/usr/local/include'] )->DoubleSize( 8 )

--- a/tests/202_misc.t
+++ b/tests/202_misc.t
@@ -18,14 +18,16 @@ BEGIN { plan tests => 207 }
 #===================================================================
 
 eval {
-  $p = new Convert::Binary::C PointerSize => 4,
-                              EnumSize    => 4,
-                              IntSize     => 4,
-                              LongSize    => 4,
-                              Alignment   => 2,
-                              ByteOrder   => 'BigEndian',
-                              EnumType    => 'String';
-  $q = new Convert::Binary::C;
+  $p = Convert::Binary::C->new(
+    PointerSize => 4,
+    EnumSize    => 4,
+    IntSize     => 4,
+    LongSize    => 4,
+    Alignment   => 2,
+    ByteOrder   => 'BigEndian',
+    EnumType    => 'String',
+  );
+  $q = Convert::Binary::C->new;
 };
 ok($@,'');
 
@@ -255,7 +257,7 @@ reccmp( $refres, $result );
 # test pack/unpack/sizeof/typeof for basic types
 #------------------------------------------------
 
-$p = new Convert::Binary::C;
+$p = Convert::Binary::C->new;
 
 @tests = (
   ['char',        $p->CharSize      ],

--- a/tests/204_enum.t
+++ b/tests/204_enum.t
@@ -14,9 +14,9 @@ $^W = 1;
 BEGIN { plan tests => 182 }
 
 eval {
-  $p = new Convert::Binary::C ByteOrder => 'BigEndian',
+  $p = Convert::Binary::C->new(ByteOrder => 'BigEndian',
                               EnumSize  => 4,
-                              EnumType  => 'Integer';
+                              EnumType  => 'Integer');
 };
 ok($@,'',"failed to create Convert::Binary::C object");
 

--- a/tests/205_pack.t
+++ b/tests/205_pack.t
@@ -14,8 +14,10 @@ $^W = 1;
 BEGIN { plan tests => 275 }
 
 eval {
-  $p = new Convert::Binary::C ByteOrder     => 'BigEndian'
-                            , UnsignedChars => 0
+  $p = Convert::Binary::C->new(
+    ByteOrder     => 'BigEndian',
+    UnsignedChars => 0,
+  );
 };
 ok($@,'',"failed to create Convert::Binary::C object");
 
@@ -431,7 +433,7 @@ ok($packed =~ /^$val.*$/);
 {
   my @res;
 
-  my $c = new Convert::Binary::C;
+  my $c = Convert::Binary::C->new;
   $c->parse(<<ENDC);
 typedef unsigned char u;
 typedef struct {

--- a/tests/206_parse.t
+++ b/tests/206_parse.t
@@ -18,7 +18,7 @@ my $CCCFG = require 'tests/include/config.pl';
 #===================================================================
 # create object (1 tests)
 #===================================================================
-eval { $p = new Convert::Binary::C };
+eval { $p = Convert::Binary::C->new };
 ok($@,'',"failed to create Convert::Binary::C object");
 
 #===================================================================
@@ -48,16 +48,18 @@ ok(ref $p, 'Convert::Binary::C',
 # create object (1 tests)
 #===================================================================
 eval {
-  $p = new Convert::Binary::C %$CCCFG,
-                              EnumSize       => 0,
-                              ShortSize      => 2,
-                              IntSize        => 4,
-                              LongSize       => 4,
-                              LongLongSize   => 8,
-                              PointerSize    => 4,
-                              FloatSize      => 4,
-                              DoubleSize     => 8,
-                              LongDoubleSize => 12;
+  $p = Convert::Binary::C->new(
+    %$CCCFG,
+    EnumSize       => 0,
+    ShortSize      => 2,
+    IntSize        => 4,
+    LongSize       => 4,
+    LongLongSize   => 8,
+    PointerSize    => 4,
+    FloatSize      => 4,
+    DoubleSize     => 8,
+    LongDoubleSize => 12,
+  );
 };
 ok($@,'',"failed to create Convert::Binary::C object");
 
@@ -388,7 +390,7 @@ my @tests = (
 );
 
 for my $t ( @tests ) {
-  my $c = new Convert::Binary::C;
+  my $c = Convert::Binary::C->new;
   my $pre  = 'struct { ' x $t->{level};
   my $post = ' x; }'     x $t->{level};
   eval { $c->parse("typedef $pre int $post deep;") };
@@ -401,7 +403,7 @@ for my $t ( @tests ) {
 # check parse error recovery (9 tests)
 #===================================================================
 
-$c = new Convert::Binary::C IntSize => 4, EnumSize => 4;
+$c = Convert::Binary::C->new(IntSize => 4, EnumSize => 4);
 
 eval {
   $c->parse(<<ENDC);

--- a/tests/207_typedef.t
+++ b/tests/207_typedef.t
@@ -13,7 +13,7 @@ $^W = 1;
 
 BEGIN { plan tests => 30 }
 
-eval { $c = new Convert::Binary::C; };
+eval { $c = Convert::Binary::C->new; };
 ok($@,'',"failed to create Convert::Binary::C object");
 
 eval {

--- a/tests/208_float.t
+++ b/tests/208_float.t
@@ -13,7 +13,7 @@ $^W = 1;
 
 BEGIN { plan tests => 30 }
 
-eval { $p = new Convert::Binary::C; };
+eval { $p = Convert::Binary::C->new; };
 ok($@,'',"failed to create Convert::Binary::C object");
 
 eval {

--- a/tests/209_sourcify.t
+++ b/tests/209_sourcify.t
@@ -16,8 +16,8 @@ BEGIN { plan tests => 98 }
 my $CCCFG = require 'tests/include/config.pl';
 
 eval {
-  $orig  = new Convert::Binary::C %$CCCFG;
-  @clone = map { new Convert::Binary::C %$CCCFG } 1 .. 2;
+  $orig  = Convert::Binary::C->new(%$CCCFG);
+  @clone = map { Convert::Binary::C->new(%$CCCFG) } 1 .. 2;
 };
 ok($@,'',"failed to create Convert::Binary::C objects");
 

--- a/tests/210_depend.t
+++ b/tests/210_depend.t
@@ -16,8 +16,8 @@ BEGIN { plan tests => 483 }
 my $CCCFG = require 'tests/include/config.pl';
 
 eval {
-  $c1 = new Convert::Binary::C Include => ['tests/include/files'];
-  $c2 = new Convert::Binary::C Include => ['tests/include/files'];
+  $c1 = Convert::Binary::C->new(Include => ['tests/include/files']);
+  $c2 = Convert::Binary::C->new(Include => ['tests/include/files']);
 };
 ok($@,'',"failed to create Convert::Binary::C objects");
 
@@ -76,7 +76,7 @@ ok( join(',', sort @ref2), join(',', sort @files2s),
     "dependency names differ" );
 
 eval {
-  $c2 = new Convert::Binary::C %$CCCFG;
+  $c2 = Convert::Binary::C->new(%$CCCFG);
   $c2->parse_file( 'tests/include/include.c' );
 };
 ok($@,'',"failed to create object / parse file");

--- a/tests/211_clone.t
+++ b/tests/211_clone.t
@@ -16,7 +16,7 @@ BEGIN { plan tests => 35 }
 my $CCCFG = require 'tests/include/config.pl';
 
 eval {
-  $orig = new Convert::Binary::C %$CCCFG;
+  $orig = Convert::Binary::C->new(%$CCCFG);
 };
 ok($@,'',"failed to create Convert::Binary::C object");
 

--- a/tests/212_clean.t
+++ b/tests/212_clean.t
@@ -14,7 +14,7 @@ $^W = 1;
 BEGIN { plan tests => 6 }
 
 eval {
-  $c = new Convert::Binary::C;
+  $c = Convert::Binary::C->new;
 };
 ok($@,'',"failed to create Convert::Binary::C object");
 

--- a/tests/213_string.t
+++ b/tests/213_string.t
@@ -14,9 +14,9 @@ $^W = 1;
 BEGIN { plan tests => 91 }
 
 eval {
-  $C{B} = new Convert::Binary::C LongSize     => 4,
+  $C{B} = Convert::Binary::C->new(LongSize     => 4,
                                  LongLongSize => 8,
-                                 ByteOrder    => 'BigEndian';
+                                 ByteOrder    => 'BigEndian');
 };
 ok($@,'',"failed to create Convert::Binary::C object");
 

--- a/tests/214_cache.t
+++ b/tests/214_cache.t
@@ -66,8 +66,8 @@ if( $Data_Dumper or $IO_File ) {
 *main::copy = sub {
   my($from, $to) = @_;
   -e $to and unlink $to || die $!;
-  my $fh = new IO::File;
-  my $th = new IO::File;
+  my $fh = IO::File->new;
+  my $th = IO::File->new;
   local $/;
   $fh->open("<$from")
     and binmode $fh
@@ -90,14 +90,18 @@ $cache = 'tests/cache.cbc';
 -e $cache and unlink $cache || die $!;
 
 eval {
-  $c = new Convert::Binary::C::Cached Cache   => [$cache],
-                                      Include => ['tests/cache'];
+  $c = Convert::Binary::C::Cached->new(
+    Cache   => [$cache],
+    Include => ['tests/cache'],
+  );
 };
 ok( $@, qr/Cache must be a string value, not a reference at \Q$0/ );
 
 eval {
-  $c = new Convert::Binary::C::Cached Cache   => $cache,
-                                      Include => ['tests/cache'];
+  $c = Convert::Binary::C::Cached->new(
+    Cache   => $cache,
+    Include => ['tests/cache'],
+  );
 };
 ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
@@ -117,8 +121,10 @@ ok( $@, qr/Cannot parse more than once for cached objects at \Q$0/ );
 # check what happens if the cache file cannot be created
 
 eval {
-  $c = new Convert::Binary::C::Cached Cache   => 'abc/def/ghi/jkl/mno.pqr',
-                                      Include => ['tests/cache'];
+  $c = Convert::Binary::C::Cached->new(
+    Cache   => 'abc/def/ghi/jkl/mno.pqr',
+    Include => ['tests/cache'],
+  );
 };
 ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
@@ -145,12 +151,12 @@ copy( qw( tests/cache/sub/dir.1 tests/cache/sub/dir.h ) );
   KeywordMap => {'__inline__' => 'inline', '__restrict__' => undef },
 );
 
-eval { $r = new Convert::Binary::C @config };
+eval { $r = Convert::Binary::C->new(@config) };
 ok($@,'',"failed to create reference Convert::Binary::C object");
 
 push @config, Cache => $cache;
 
-eval { $c = new Convert::Binary::C::Cached @config };
+eval { $c = Convert::Binary::C::Cached->new(@config) };
 ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
 eval {
@@ -171,7 +177,7 @@ ok( -e $cache );
 
 # this new object should now use the cache file
 
-eval { $c = new Convert::Binary::C::Cached @config };
+eval { $c = Convert::Binary::C::Cached->new(@config) };
 ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
 eval {
@@ -194,7 +200,7 @@ for( qw( tests/cache/sub/dir tests/cache/header tests/cache/cache ) ) {
   copy( "$_.2", "$_.h" );
   /dir/ and sleep 2;
 
-  eval { $c = new Convert::Binary::C::Cached @config };
+  eval { $c = Convert::Binary::C::Cached->new(@config) };
   ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
   eval {
@@ -208,7 +214,7 @@ for( qw( tests/cache/sub/dir tests/cache/header tests/cache/cache ) ) {
 
   ok( compare( $r, $c ) );
 
-  eval { $c = new Convert::Binary::C::Cached @config };
+  eval { $c = Convert::Binary::C::Cached->new(@config) };
   ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
   eval {
@@ -226,7 +232,7 @@ for( qw( tests/cache/sub/dir tests/cache/header tests/cache/cache ) ) {
 
 # changing the way we're parsing should trigger re-parsing
 
-eval { $c = new Convert::Binary::C::Cached @config };
+eval { $c = Convert::Binary::C::Cached->new(@config) };
 ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
 eval {
@@ -244,7 +250,7 @@ ok( $c->__uses_cache, 0, "object is using cache file" );
 
 ok( compare( $r, $c ) );
 
-eval { $c = new Convert::Binary::C::Cached @config };
+eval { $c = Convert::Binary::C::Cached->new(@config) };
 ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
 eval {
@@ -263,7 +269,7 @@ ok( compare( $r, $c ) );
 
 # changing the embedded code should trigger re-parsing
 
-eval { $c = new Convert::Binary::C::Cached @config };
+eval { $c = Convert::Binary::C::Cached->new(@config) };
 ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
 eval {
@@ -283,7 +289,7 @@ ok( $c->__uses_cache, 0, "object is using cache file" );
 
 ok( compare( $r, $c ) );
 
-eval { $c = new Convert::Binary::C::Cached @config };
+eval { $c = Convert::Binary::C::Cached->new(@config) };
 ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
 eval {
@@ -305,7 +311,7 @@ ok( compare( $r, $c ) );
 
 push @config, Define => ['BAR'];
 
-eval { $c = new Convert::Binary::C::Cached @config };
+eval { $c = Convert::Binary::C::Cached->new(@config) };
 ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
 eval {
@@ -325,7 +331,7 @@ ok( $c->__uses_cache, 0, "object is using cache file" );
 
 ok( compare( $r, $c ) );
 
-eval { $c = new Convert::Binary::C::Cached @config };
+eval { $c = Convert::Binary::C::Cached->new(@config) };
 ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
 eval {
@@ -351,7 +357,7 @@ cleanup();
 # check cache file corruption
 
 $code = 'typedef int foo;';
-eval { $c = new Convert::Binary::C::Cached Cache => $cache };
+eval { $c = Convert::Binary::C::Cached->new(Cache => $cache) };
 ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
 eval { $c->parse( $code ) };
@@ -381,7 +387,7 @@ for( $pos = 0; $pos < $size; $pos++ ) {
   {
     local $SIG{__WARN__} = sub { push @warn, $_[0] };
 
-    eval { $c = new Convert::Binary::C::Cached Cache => $cache };
+    eval { $c = Convert::Binary::C::Cached->new(Cache => $cache) };
     if( $@ ne '' ) {
       $@ =~ s/^/# /gm;
       print "# failed to create Convert::Binary::C::Cached object\n$@";

--- a/tests/215_local.t
+++ b/tests/215_local.t
@@ -18,7 +18,7 @@ BEGIN {
 my $CCCFG = require 'tests/include/config.pl';
 
 eval {
-  $c = new Convert::Binary::C;
+  $c = Convert::Binary::C->new;
 };
 ok($@,'',"failed to create Convert::Binary::C::Cached object");
 

--- a/tests/216_language.t
+++ b/tests/216_language.t
@@ -14,7 +14,7 @@ $^W = 1;
 BEGIN { plan tests => 43 }
 
 eval {
-  $c = new Convert::Binary::C;
+  $c = Convert::Binary::C->new;
 };
 ok($@,'',"failed to create Convert::Binary::C object");
 

--- a/tests/219_def.t
+++ b/tests/219_def.t
@@ -18,7 +18,7 @@ BEGIN {
 $SIG{__WARN__} = sub { push @warn, $_[0] };
 
 eval {
-  $c = new Convert::Binary::C;
+  $c = Convert::Binary::C->new;
 };
 ok($@,'',"failed to create Convert::Binary::C object");
 

--- a/tests/226_indexed.t
+++ b/tests/226_indexed.t
@@ -16,7 +16,7 @@ BEGIN { plan tests => 45 }
 my $reason = do {
   my @w;
   local $SIG{__WARN__} = sub { push @w, @_ };
-  my $c = new Convert::Binary::C OrderMembers => 1;
+  my $c = Convert::Binary::C->new(OrderMembers => 1);
   (grep /Couldn't load a module for member ordering/, @w)
   ? "member ordering requires indexed hashes" : "";
 };
@@ -26,8 +26,8 @@ my $order = $reason ? 0 : 1;
 my @keys = grep !/do|if/, 'aa' .. 'zz';
 my $members = join "\n", map "unsigned char $_;", @keys;
 
-my $u = new Convert::Binary::C OrderMembers => 0;
-my $o = new Convert::Binary::C OrderMembers => $order;
+my $u = Convert::Binary::C->new(OrderMembers => 0);
+my $o = Convert::Binary::C->new(OrderMembers => $order);
 
 for my $c ( $u, $o ) {
   $c->parse( <<ENDC );

--- a/tests/227_flexarray.t
+++ b/tests/227_flexarray.t
@@ -13,7 +13,7 @@ $^W = 1;
 
 BEGIN { plan tests => 49 }
 
-my $c = new Convert::Binary::C IntSize => 4, ShortSize => 2, Alignment => 4;
+my $c = Convert::Binary::C->new(IntSize => 4, ShortSize => 2, Alignment => 4);
 
 $c->parse(<<ENDC);
 

--- a/tests/228_hooks.t
+++ b/tests/228_hooks.t
@@ -20,11 +20,11 @@ unless ($reason) {
   $reason = 'cannot use dualvar()' if $@;
 }
 
-my $c = new Convert::Binary::C ByteOrder   => 'BigEndian',
+my $c = Convert::Binary::C->new(ByteOrder   => 'BigEndian',
                                EnumType    => 'String',
                                EnumSize    => 4,
                                IntSize     => 4,
-                               PointerSize => 4;
+                               PointerSize => 4);
 
 $c->parse(<<'ENDC');
 

--- a/tests/229_substr.t
+++ b/tests/229_substr.t
@@ -34,7 +34,7 @@ sub chkwarn {
   @warn = ();
 }
 
-$c = new Convert::Binary::C ByteOrder => 'BigEndian', IntSize => 4;
+$c = Convert::Binary::C->new(ByteOrder => 'BigEndian', IntSize => 4);
 $c->parse("typedef unsigned int u_32;");
 
 $ref  = pack "N*", 1000000, 5000000, 3000000, 4000000;

--- a/tests/230_compiler.t
+++ b/tests/230_compiler.t
@@ -39,7 +39,7 @@ for my $cur (sort keys %cc) {
 
   do $cc{$cur}{cfg};
 
-  my $c = new Convert::Binary::C %config;
+  my $c = Convert::Binary::C->new(%config);
   $c->parse_file('tests/compiler/test.h');
   my $pck = $c->pack('test', $dat);
 

--- a/tests/231_align.t
+++ b/tests/231_align.t
@@ -13,9 +13,10 @@ $^W = 1;
 
 BEGIN { plan tests => 212 }
 
-$c = new Convert::Binary::C ShortSize => 2
-                          , LongSize  => 4
-                          ;
+$c = Convert::Binary::C->new(
+    ShortSize => 2,
+    LongSize  => 4,
+);
 
 eval { $c->parse(<<ENDC) };
 

--- a/tests/232_native.t
+++ b/tests/232_native.t
@@ -30,7 +30,7 @@ eval {
 };
 ok($@, qr/^Invalid property 'EnumType'/);
 
-$c = new Convert::Binary::C;
+$c = Convert::Binary::C->new();
 eval {
   $s2 = $c->native('IntSize');
 };

--- a/tests/233_tags.t
+++ b/tests/233_tags.t
@@ -13,7 +13,7 @@ $^W = 1;
 
 BEGIN { plan tests => 148 }
 
-my $c = new Convert::Binary::C;
+my $c = Convert::Binary::C->new();
 
 eval {
   $c->parse(<<ENDC);

--- a/tests/234_format.t
+++ b/tests/234_format.t
@@ -15,8 +15,12 @@ BEGIN { plan tests => 148 }
 
 # TODO: different alignments
 
-my $c = new Convert::Binary::C ByteOrder => 'LittleEndian',
-                               IntSize => 4, CharSize => 1, EnumSize => 4;
+my $c = Convert::Binary::C->new(
+    ByteOrder => 'LittleEndian',
+    IntSize => 4,
+    CharSize => 1,
+    EnumSize => 4,
+);
 
 eval {
   $c->parse(<<ENDC);

--- a/tests/235_basic.t
+++ b/tests/235_basic.t
@@ -13,7 +13,7 @@ $^W = 1;
 
 BEGIN { plan tests => 54 }
 
-my $c = new Convert::Binary::C;
+my $c = Convert::Binary::C->new();
 
 for my $t ( 'char'
           , 'signed char'

--- a/tests/236_typeinfo.t
+++ b/tests/236_typeinfo.t
@@ -13,7 +13,7 @@ $^W = 1;
 
 BEGIN { plan tests => 49 }
 
-my $c = new Convert::Binary::C;
+my $c = Convert::Binary::C->new();
 
 $c->parse(<<ENDC);
 

--- a/tests/238_byteorder.t
+++ b/tests/238_byteorder.t
@@ -9,8 +9,11 @@
 use Test::More tests => 32;
 use Convert::Binary::C @ARGV;
 
-my $c = new Convert::Binary::C ByteOrder => 'LittleEndian',
-                               IntSize => 4, EnumSize => 4;
+my $c = Convert::Binary::C->new(
+    ByteOrder => 'LittleEndian',
+    IntSize => 4,
+    EnumSize => 4,
+);
 
 eval {
   $c->parse(<<ENDC);

--- a/tests/239_macros.t
+++ b/tests/239_macros.t
@@ -12,7 +12,7 @@ use Convert::Binary::C @ARGV;
 my @stdname = qw( __STDC_HOSTED__ __STDC_VERSION__ );
 my @stddef  = qw( __STDC_HOSTED__=1 __STDC_VERSION__=199901L );
 
-my $c = new Convert::Binary::C;
+my $c = Convert::Binary::C->new();
 
 eval {
   $c->parse('');

--- a/tests/240_offsetof.t
+++ b/tests/240_offsetof.t
@@ -9,7 +9,7 @@
 use Test::More tests => 377;
 use Convert::Binary::C @ARGV;
 
-my $c = new Convert::Binary::C IntSize => 4, CharSize => 1, Alignment => 1;
+my $c = Convert::Binary::C->new(IntSize => 4, CharSize => 1, Alignment => 1);
 
 eval {
 $c->parse(<<'ENDC');

--- a/tests/241_sizeof.t
+++ b/tests/241_sizeof.t
@@ -9,7 +9,7 @@
 use Test::More tests => 71;
 use Convert::Binary::C @ARGV;
 
-my $c = new Convert::Binary::C IntSize => 4, CharSize => 1, Alignment => 1;
+my $c = Convert::Binary::C->new(IntSize => 4, CharSize => 1, Alignment => 1);
 
 eval {
 $c->parse(<<'ENDC');

--- a/tests/242_dimension.t
+++ b/tests/242_dimension.t
@@ -12,11 +12,13 @@ use strict;
 
 $^W = 1;
 
-my $c = new Convert::Binary::C CharSize  => 1
-                             , ShortSize => 2
-                             , IntSize   => 4
-                             , Alignment => 1
-                             , ByteOrder => 'BigEndian';
+my $c = Convert::Binary::C->new(
+    CharSize  => 1,
+    ShortSize => 2,
+    IntSize   => 4,
+    Alignment => 1,
+    ByteOrder => 'BigEndian',
+);
 
 $c->parse(<<'ENDC');
 

--- a/tests/243_parser.t
+++ b/tests/243_parser.t
@@ -12,7 +12,7 @@ use strict;
 
 $^W = 1;
 
-my $c = new Convert::Binary::C;
+my $c = Convert::Binary::C->new();
 
 eval { $c->parse_file('tests/parser/context.c') };
 

--- a/tests/601_speed.t
+++ b/tests/601_speed.t
@@ -66,7 +66,7 @@ $start_time = mytime();
 $fail = 0;
 do {
   eval {
-    $c = new Convert::Binary::C %$CCCFG;
+    $c = Convert::Binary::C->new(%$CCCFG);
     $c->parse_file( 'tests/include/include.c' );
   };
   $@ and $fail = 1 and last;
@@ -89,7 +89,7 @@ print "# uncached: $iterations iterations in $elapsed_time seconds\n";
 
 # create cache file
 eval {
-  $c = new Convert::Binary::C::Cached Cache => $cache, %$CCCFG;
+  $c = Convert::Binary::C::Cached->new(Cache => $cache, %$CCCFG);
 
   $c->parse_file( 'tests/include/include.c' );
 };
@@ -102,7 +102,7 @@ ok( -e $cache );
 $start_time = mytime();
 eval {
   for( 1 .. $iterations ) {
-    $c = new Convert::Binary::C::Cached Cache => $cache, %$CCCFG;
+    $c = Convert::Binary::C::Cached->new(Cache => $cache, %$CCCFG);
     $c->parse_file( 'tests/include/include.c' );
   }
 };

--- a/tests/602_threads.t
+++ b/tests/602_threads.t
@@ -56,16 +56,18 @@ sub task
   my $p;
 
   eval {
-    $p = new Convert::Binary::C %$CCCFG,
-                                EnumSize       => 0,
-                                ShortSize      => 2,
-                                IntSize        => 4,
-                                LongSize       => 4,
-                                LongLongSize   => 8,
-                                PointerSize    => 4,
-                                FloatSize      => 4,
-                                DoubleSize     => 8,
-                                LongDoubleSize => 12;
+    $p = Convert::Binary::C->new(
+        %$CCCFG,
+        EnumSize       => 0,
+        ShortSize      => 2,
+        IntSize        => 4,
+        LongSize       => 4,
+        LongLongSize   => 8,
+        PointerSize    => 4,
+        FloatSize      => 4,
+        DoubleSize     => 8,
+        LongDoubleSize => 12,
+    );
     if ($arg % 2) {
       print "# parse_file ($arg) called\n";
       $p->parse_file('tests/include/include.c');

--- a/tests/603_complex.t
+++ b/tests/603_complex.t
@@ -3013,14 +3013,16 @@ sub checkrc
   }
 }
 
-my $p = new Convert::Binary::C ByteOrder   => 'LittleEndian',
-                               ShortSize   => 2,
-                               IntSize     => 4,
-                               LongSize    => 4,
-                               PointerSize => 4,
-                               FloatSize   => 4,
-                               DoubleSize  => 8,
-                               Alignment   => 4;
+my $p = Convert::Binary::C->new(
+    ByteOrder   => 'LittleEndian',
+    ShortSize   => 2,
+    IntSize     => 4,
+    LongSize    => 4,
+    PointerSize => 4,
+    FloatSize   => 4,
+    DoubleSize  => 8,
+    Alignment   => 4,
+);
 
 $p->parse($types);
 

--- a/tests/701_debug.t
+++ b/tests/701_debug.t
@@ -41,7 +41,7 @@ else {
 ok( -e $dbfile xor not $debug );
 ok( -z $dbfile xor not $debug );
 
-eval { $p = new Convert::Binary::C };
+eval { $p = Convert::Binary::C->new };
 
 ok( $@, '' );
 ok( ref $p, 'Convert::Binary::C' );
@@ -81,7 +81,7 @@ else {
 @warnings = ();
 
 eval qq{
-  import Convert::Binary::C 'debug';
+  Convert::Binary::C->import('debug');
 };
 
 ok( $@, qr/^You must pass an even number of module arguments/ );


### PR DESCRIPTION
Hi,

I received your dist in this month's [CPAN PR Challenge](http://cpan-prc.org/).  When looking through the docs and examples, I noticed a few places where usage of indirect object syntax was still in use.

This minimal set of changes uses the ```Foo->new()``` syntax instead.

Thanks,
Chase