### PR TITLE
Remove use of indirect object notation in tests

### DIFF
--- a/tests/001_init.t
+++ b/tests/001_init.t
@@ -20,12 +20,12 @@ require_ok('Convert::Binary::C::Cached');
 #===================================================================
 # check if we build the right object (4 tests)
 #===================================================================
-eval { $p = new Convert::Binary::C };
+eval { $p = Convert::Binary::C->new };
 is($@, '', "create Convert::Binary::C object");
 is(ref $p, 'Convert::Binary::C',
    "blessed Convert::Binary::C reference");
 
-eval { $p = new Convert::Binary::C::Cached };
+eval { $p = Convert::Binary::C::Cached->new };
 is($@, '', "create Convert::Binary::C::Cached object");
 is(ref $p, 'Convert::Binary::C::Cached',
    "blessed Convert::Binary::C::Cached reference");
@@ -34,12 +34,14 @@ is(ref $p, 'Convert::Binary::C::Cached',
 # check initialization during construction (4 tests)
 #===================================================================
 eval {
-  $p = new Convert::Binary::C PointerSize => 4,
-                              EnumSize    => 4,
-                              IntSize     => 4,
-                              Alignment   => 2,
-                              ByteOrder   => 'BigEndian',
-                              EnumType    => 'Both';
+  $p = Convert::Binary::C->new(
+    PointerSize => 4,
+    EnumSize    => 4,
+    IntSize     => 4,
+    Alignment   => 2,
+    ByteOrder   => 'BigEndian',
+    EnumType    => 'Both'
+  );
 };
 is($@, '', "create Convert::Binary::C object with arguments");
 is(ref $p, 'Convert::Binary::C',
@@ -48,13 +50,15 @@ is(ref $p, 'Convert::Binary::C',
 @warn = ();
 eval {
   local $SIG{__WARN__} = sub { push @warn, $_[0] };
-  $p = new Convert::Binary::C::Cached Cache       => 'tests/cache.cbc',
-                                      PointerSize => 4,
-                                      EnumSize    => 4,
-                                      IntSize     => 4,
-                                      Alignment   => 2,
-                                      ByteOrder   => 'BigEndian',
-                                      EnumType    => 'Both';
+  $p = Convert::Binary::C::Cached->new(
+    Cache       => 'tests/cache.cbc',
+    PointerSize => 4,
+    EnumSize    => 4,
+    IntSize     => 4,
+    Alignment   => 2,
+    ByteOrder   => 'BigEndian',
+    EnumType    => 'Both'
+  );
 };
 is($@, '', "create Convert::Binary::C::Cached object with arguments");
 is(ref $p, 'Convert::Binary::C::Cached',
@@ -76,12 +80,12 @@ else { pass('warnings') }
 # check unknown options in constructor (2 tests)
 #===================================================================
 eval {
-  $p = new Convert::Binary::C FOO => 123, ByteOrder => 'BigEndian', BAR => ['abc'];
+  $p = Convert::Binary::C->new( FOO => 123, ByteOrder => 'BigEndian', BAR => ['abc'] );
 };
 like($@, qr/Invalid option 'FOO' at \Q$0/);
 
 eval {
-  $p = new Convert::Binary::C::Cached FOO => 123, ByteOrder => 'BigEndian', BAR => ['abc'];
+  $p = Convert::Binary::C::Cached->new( FOO => 123, ByteOrder => 'BigEndian', BAR => ['abc'] );
 };
 like($@, qr/Invalid option 'FOO' at \Q$0/);
 
@@ -89,12 +93,12 @@ like($@, qr/Invalid option 'FOO' at \Q$0/);
 # check invalid construction (2 tests)
 #===================================================================
 eval {
-  $p = new Convert::Binary::C FOO;
+  $p = Convert::Binary::C->new( FOO );
 };
 like($@, qr/Number of configuration arguments to new must be even at \Q$0/);
 
 eval {
-  $p = new Convert::Binary::C::Cached FOO;
+  $p = Convert::Binary::C::Cached->new( FOO );
 };
 like($@, qr/Number of configuration arguments to new must be even at \Q$0/);
 
@@ -102,12 +106,12 @@ like($@, qr/Number of configuration arguments to new must be even at \Q$0/);
 # check invalid construction (2 tests)
 #===================================================================
 eval {
-  $p = new Convert::Binary::C ByteOrder => 'FOO';
+  $p = Convert::Binary::C->new( ByteOrder => 'FOO' );
 };
 like($@, qr/ByteOrder must be.*not 'FOO' at \Q$0/);
 
 eval {
-  $p = new Convert::Binary::C::Cached ByteOrder => 'FOO';
+  $p = Convert::Binary::C::Cached->new( ByteOrder => 'FOO' );
 };
 like($@, qr/ByteOrder must be.*not 'FOO' at \Q$0/);
 
@@ -124,7 +128,7 @@ ok(not defined $p);
 # check calling feature as method (2 tests)
 #===================================================================
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p = $p->feature('debug');
 };
 is($@, '');

--- a/tests/101_basic.t
+++ b/tests/101_basic.t
@@ -48,14 +48,16 @@ print "1..211\n";
 #===================================================================
 
 eval {
-  $p = new Convert::Binary::C PointerSize => 4,
-                              EnumSize    => 4,
-                              IntSize     => 4,
-                              LongSize    => 4,
-                              Alignment   => 2,
-                              ByteOrder   => 'BigEndian',
-                              EnumType    => 'String';
-  $q = new Convert::Binary::C;
+  $p = Convert::Binary::C->new(
+    PointerSize => 4,
+    EnumSize    => 4,
+    IntSize     => 4,
+    LongSize    => 4,
+    Alignment   => 2,
+    ByteOrder   => 'BigEndian',
+    EnumType    => 'String'
+  );
+  $q = Convert::Binary::C->new;
 };
 ok($@,'');
 
@@ -285,7 +287,7 @@ reccmp( $refres, $result );
 # test pack/unpack/sizeof/typeof for basic types
 #------------------------------------------------
 
-$p = new Convert::Binary::C;
+$p = Convert::Binary::C->new;
 
 @tests = (
   ['char',        $p->CharSize      ],

--- a/tests/201_config.t
+++ b/tests/201_config.t
@@ -48,7 +48,7 @@ sub check_config
 
       my $reference = $config->{out} || $config->{in};
 
-      eval { $p = new Convert::Binary::C };
+      eval { $p = Convert::Binary::C->new };
       skip($reason, $@, '', "failed to create Convert::Binary::C object");
 
       print "# \$p->configure( $option => $config->{in} )\n";
@@ -159,7 +159,7 @@ sub check_option_strlist
   for my $config ( @tests ) {
     @warn = ();
 
-    eval { $p = new Convert::Binary::C };
+    eval { $p = Convert::Binary::C->new };
     ok($@, '', "failed to create Convert::Binary::C object");
 
     print "# \$p->configure( $option => $config->{in} )\n";
@@ -223,7 +223,7 @@ sub check_option_strlist_args {
   my $option = shift;
   my @warn;
   eval {
-    $p = new Convert::Binary::C;
+    $p = Convert::Binary::C->new;
     $p->$option( [qw(foo bar)] );
     $p->$option( 'include' );
     $p->$option( qw(a b c) );
@@ -433,19 +433,19 @@ check_option_strlist_args( $_ ) for qw( Include
 #===================================================================
 
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p->configure( DisabledKeywords => ['void', 'foo', 'const'] );
 };
 ok( $@, qr/Cannot disable unknown keyword 'foo'.*$thisfile/ );
 
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p->DisabledKeywords( 'void', 'foo', 'const' );
 };
 ok( $@, qr/DisabledKeywords cannot take more than one argument.*$thisfile/ );
 
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p->DisabledKeywords( ['auto', 'enum'] );
   $p->DisabledKeywords( ['void', 'while', 'register'] );
 };
@@ -458,43 +458,43 @@ ok( "@$kw", "auto enum", 'DisabledKeywords did not preserve configuration' );
 #===================================================================
 
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p->configure( KeywordMap => 5 );
 };
 ok( $@, qr/KeywordMap wants a hash reference.*$thisfile/ );
 
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p->configure( KeywordMap => [ __xxx__ => 'foo' ] );
 };
 ok( $@, qr/KeywordMap wants a hash reference.*$thisfile/ );
 
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p->KeywordMap( { '' => 'int' } );
 };
 ok( $@, qr/Cannot use empty string as a keyword.*$thisfile/ );
 
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p->KeywordMap( { '1_d' => 'int' } );
 };
 ok( $@, qr/Cannot use '1_d' as a keyword.*$thisfile/ );
 
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p->KeywordMap( { '_d' => [] } );
 };
 ok( $@, qr/Cannot use a reference as a keyword.*$thisfile/ );
 
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p->KeywordMap( { '_d' => 'foo' } );
 };
 ok( $@, qr/Cannot use 'foo' as a keyword.*$thisfile/ );
 
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p->KeywordMap( {'__const' => 'const', '__restrict' => undef} );
   $p->KeywordMap( {'__volatile' => 'volatile', '__foo' => 'foo'} );
 };
@@ -512,7 +512,7 @@ ok( "@{[sort keys %$kw]}", "__const __restrict", 'KeywordMap did not preserve co
 foreach $config ( @tests )
 {
   eval {
-    $p = new Convert::Binary::C;
+    $p = Convert::Binary::C->new;
     $p->configure( @{$config->{value}} );
   };
   ok( ($@ eq '' ? SUCCEED : FAIL), $config->{result},
@@ -524,7 +524,7 @@ foreach $config ( @tests )
 # check invalid option
 #===================================================================
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p->configure(
     Something => 'xxx',
     ByteOrder => 'BigEndian',
@@ -537,7 +537,7 @@ ok( $@, qr/Invalid option 'Something'.*$thisfile/ );
 # check invalid method
 #===================================================================
 eval {
-  $p = new Convert::Binary::C;
+  $p = Convert::Binary::C->new;
   $p->some_method( 1, 2, 3 );
 };
 ok( $@, qr/Invalid method some_method called.*$thisfile/ );
@@ -578,7 +578,7 @@ ok( $@, qr/Invalid method some_method called.*$thisfile/ );
 );
 
 eval {
-  $p = new Convert::Binary::C %config;
+  $p = Convert::Binary::C->new( %config );
   $cfg = $p->configure;
 };
 ok( $@, '', "failed to retrieve configuration" );
@@ -625,7 +625,7 @@ ok( compare_config( \%config, $cfg ) );
 eval {
   local $SIG{__WARN__} = sub { push @warn, shift };
 
-  $p = new Convert::Binary::C %config;
+  $p = Convert::Binary::C->new( %config );
 
   $p->UnsignedChars( 1 )->configure( ShortSize => 4, EnumType => 'Both', EnumSize => 0 )
     ->Include( ['/usr/local/include'] )->DoubleSize( 8 )

--- a/tests/202_misc.t
+++ b/tests/202_misc.t
@@ -18,14 +18,16 @@ BEGIN { plan tests => 207 }
 #===================================================================
 
 eval {
-  $p = new Convert::Binary::C PointerSize => 4,
-                              EnumSize    => 4,
-                              IntSize     => 4,
-                              LongSize    => 4,
-                              Alignment   => 2,
-                              ByteOrder   => 'BigEndian',
-                              EnumType    => 'String';
-  $q = new Convert::Binary::C;
+  $p = Convert::Binary::C->new(
+    PointerSize => 4,
+    EnumSize    => 4,
+    IntSize     => 4,
+    LongSize    => 4,
+    Alignment   => 2,
+    ByteOrder   => 'BigEndian',
+    EnumType    => 'String'
+  );
+  $q = Convert::Binary::C->new;
 };
 ok($@,'');
 
@@ -255,7 +257,7 @@ reccmp( $refres, $result );
 # test pack/unpack/sizeof/typeof for basic types
 #------------------------------------------------
 
-$p = new Convert::Binary::C;
+$p = Convert::Binary::C->new;
 
 @tests = (
   ['char',        $p->CharSize      ],

--- a/tests/204_enum.t
+++ b/tests/204_enum.t
@@ -14,9 +14,11 @@ $^W = 1;
 BEGIN { plan tests => 182 }
 
 eval {
-  $p = new Convert::Binary::C ByteOrder => 'BigEndian',
-                              EnumSize  => 4,
-                              EnumType  => 'Integer';
+  $p = Convert::Binary::C->new(
+    ByteOrder => 'BigEndian',
+    EnumSize  => 4,
+    EnumType  => 'Integer'
+  );
 };
 ok($@,'',"failed to create Convert::Binary::C object");
 

--- a/tests/205_pack.t
+++ b/tests/205_pack.t
@@ -14,8 +14,7 @@ $^W = 1;
 BEGIN { plan tests => 275 }
 
 eval {
-  $p = new Convert::Binary::C ByteOrder     => 'BigEndian'
-                            , UnsignedChars => 0
+  $p = Convert::Binary::C->new( ByteOrder => 'BigEndian', UnsignedChars => 0 );
 };
 ok($@,'',"failed to create Convert::Binary::C object");
 
@@ -431,7 +430,7 @@ ok($packed =~ /^$val.*$/);
 {
   my @res;
 
-  my $c = new Convert::Binary::C;
+  my $c = Convert::Binary::C->new;
   $c->parse(<<ENDC);
 typedef unsigned char u;
 typedef struct {

--- a/tests/206_parse.t
+++ b/tests/206_parse.t
@@ -18,7 +18,7 @@ my $CCCFG = require 'tests/include/config.pl';
 #===================================================================
 # create object (1 tests)
 #===================================================================
-eval { $p = new Convert::Binary::C };
+eval { $p = Convert::Binary::C->new };
 ok($@,'',"failed to create Convert::Binary::C object");
 
 #===================================================================
@@ -48,16 +48,18 @@ ok(ref $p, 'Convert::Binary::C',
 # create object (1 tests)
 #===================================================================
 eval {
-  $p = new Convert::Binary::C %$CCCFG,
-                              EnumSize       => 0,
-                              ShortSize      => 2,
-                              IntSize        => 4,
-                              LongSize       => 4,
-                              LongLongSize   => 8,
-                              PointerSize    => 4,
-                              FloatSize      => 4,
-                              DoubleSize     => 8,
-                              LongDoubleSize => 12;
+  $p = Convert::Binary::C->new(
+    %$CCCFG,
+    EnumSize       => 0,
+    ShortSize      => 2,
+    IntSize        => 4,
+    LongSize       => 4,
+    LongLongSize   => 8,
+    PointerSize    => 4,
+    FloatSize      => 4,
+    DoubleSize     => 8,
+    LongDoubleSize => 12
+  );
 };
 ok($@,'',"failed to create Convert::Binary::C object");
 
@@ -388,7 +390,7 @@ my @tests = (
 );
 
 for my $t ( @tests ) {
-  my $c = new Convert::Binary::C;
+  my $c = Convert::Binary::C->new;
   my $pre  = 'struct { ' x $t->{level};
   my $post = ' x; }'     x $t->{level};
   eval { $c->parse("typedef $pre int $post deep;") };
@@ -401,7 +403,7 @@ for my $t ( @tests ) {
 # check parse error recovery (9 tests)
 #===================================================================
 
-$c = new Convert::Binary::C IntSize => 4, EnumSize => 4;
+$c = Convert::Binary::C->new( IntSize => 4, EnumSize => 4 );
 
 eval {
   $c->parse(<<ENDC);

--- a/tests/207_typedef.t
+++ b/tests/207_typedef.t
@@ -13,7 +13,7 @@ $^W = 1;
 
 BEGIN { plan tests => 30 }
 
-eval { $c = new Convert::Binary::C; };
+eval { $c = Convert::Binary::C->new; };
 ok($@,'',"failed to create Convert::Binary::C object");
 
 eval {

--- a/tests/208_float.t
+++ b/tests/208_float.t
@@ -13,7 +13,7 @@ $^W = 1;
 
 BEGIN { plan tests => 30 }
 
-eval { $p = new Convert::Binary::C; };
+eval { $p = Convert::Binary::C->new; };
 ok($@,'',"failed to create Convert::Binary::C object");
 
 eval {

--- a/tests/209_sourcify.t
+++ b/tests/209_sourcify.t
@@ -16,8 +16,8 @@ BEGIN { plan tests => 98 }
 my $CCCFG = require 'tests/include/config.pl';
 
 eval {
-  $orig  = new Convert::Binary::C %$CCCFG;
-  @clone = map { new Convert::Binary::C %$CCCFG } 1 .. 2;
+  $orig  = Convert::Binary::C->new( %$CCCFG );
+  @clone = map { Convert::Binary::C->new( %$CCCFG ) } 1 .. 2;
 };
 ok($@,'',"failed to create Convert::Binary::C objects");
 

--- a/tests/210_depend.t
+++ b/tests/210_depend.t
@@ -16,8 +16,8 @@ BEGIN { plan tests => 483 }
 my $CCCFG = require 'tests/include/config.pl';
 
 eval {
-  $c1 = new Convert::Binary::C Include => ['tests/include/files'];
-  $c2 = new Convert::Binary::C Include => ['tests/include/files'];
+  $c1 = Convert::Binary::C->new( Include => ['tests/include/files'] );
+  $c2 = Convert::Binary::C->new( Include => ['tests/include/files'] );
 };
 ok($@,'',"failed to create Convert::Binary::C objects");
 
@@ -76,7 +76,7 @@ ok( join(',', sort @ref2), join(',', sort @files2s),
     "dependency names differ" );
 
 eval {
-  $c2 = new Convert::Binary::C %$CCCFG;
+  $c2 = Convert::Binary::C->new( %$CCCFG );
   $c2->parse_file( 'tests/include/include.c' );
 };
 ok($@,'',"failed to create object / parse file");

--- a/tests/211_clone.t
+++ b/tests/211_clone.t
@@ -16,7 +16,7 @@ BEGIN { plan tests => 35 }
 my $CCCFG = require 'tests/include/config.pl';
 
 eval {
-  $orig = new Convert::Binary::C %$CCCFG;
+  $orig = Convert::Binary::C->new( %$CCCFG );
 };
 ok($@,'',"failed to create Convert::Binary::C object");
 

--- a/tests/212_clean.t
+++ b/tests/212_clean.t
@@ -14,7 +14,7 @@ $^W = 1;
 BEGIN { plan tests => 6 }
 
 eval {
-  $c = new Convert::Binary::C;
+  $c = Convert::Binary::C->new;
 };
 ok($@,'',"failed to create Convert::Binary::C object");
 

--- a/tests/213_string.t
+++ b/tests/213_string.t
@@ -14,9 +14,11 @@ $^W = 1;
 BEGIN { plan tests => 91 }
 
 eval {
-  $C{B} = new Convert::Binary::C LongSize     => 4,
-                                 LongLongSize => 8,
-                                 ByteOrder    => 'BigEndian';
+  $C{B} = Convert::Binary::C->new(
+    LongSize     => 4,
+    LongLongSize => 8,
+    ByteOrder    => 'BigEndian'
+  );
 };
 ok($@,'',"failed to create Convert::Binary::C object");
 

--- a/tests/214_cache.t
+++ b/tests/214_cache.t
@@ -66,8 +66,8 @@ if( $Data_Dumper or $IO_File ) {
 *main::copy = sub {
   my($from, $to) = @_;
   -e $to and unlink $to || die $!;
-  my $fh = new IO::File;
-  my $th = new IO::File;
+  my $fh = IO::File->new;
+  my $th = IO::File->new;
   local $/;
   $fh->open("<$from")
     and binmode $fh
@@ -90,14 +90,18 @@ $cache = 'tests/cache.cbc';
 -e $cache and unlink $cache || die $!;
 
 eval {
-  $c = new Convert::Binary::C::Cached Cache   => [$cache],
-                                      Include => ['tests/cache'];
+  $c = Convert::Binary::C::Cached->new(
+    Cache   => [$cache],
+    Include => ['tests/cache']
+  );
 };
 ok( $@, qr/Cache must be a string value, not a reference at \Q$0/ );
 
 eval {
-  $c = new Convert::Binary::C::Cached Cache   => $cache,
-                                      Include => ['tests/cache'];
+  $c = Convert::Binary::C::Cached->new(
+    Cache   => $cache,
+    Include => ['tests/cache']
+  );
 };
 ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
@@ -117,8 +121,10 @@ ok( $@, qr/Cannot parse more than once for cached objects at \Q$0/ );
 # check what happens if the cache file cannot be created
 
 eval {
-  $c = new Convert::Binary::C::Cached Cache   => 'abc/def/ghi/jkl/mno.pqr',
-                                      Include => ['tests/cache'];
+  $c = Convert::Binary::C::Cached->new(
+    Cache   => 'abc/def/ghi/jkl/mno.pqr',
+    Include => ['tests/cache']
+  );
 };
 ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
@@ -145,12 +151,12 @@ copy( qw( tests/cache/sub/dir.1 tests/cache/sub/dir.h ) );
   KeywordMap => {'__inline__' => 'inline', '__restrict__' => undef },
 );
 
-eval { $r = new Convert::Binary::C @config };
+eval { $r = Convert::Binary::C->new( @config ) };
 ok($@,'',"failed to create reference Convert::Binary::C object");
 
 push @config, Cache => $cache;
 
-eval { $c = new Convert::Binary::C::Cached @config };
+eval { $c = Convert::Binary::C::Cached->new( @config ) };
 ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
 eval {
@@ -171,7 +177,7 @@ ok( -e $cache );
 
 # this new object should now use the cache file
 
-eval { $c = new Convert::Binary::C::Cached @config };
+eval { $c = Convert::Binary::C::Cached->new( @config ) };
 ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
 eval {
@@ -194,7 +200,7 @@ for( qw( tests/cache/sub/dir tests/cache/header tests/cache/cache ) ) {
   copy( "$_.2", "$_.h" );
   /dir/ and sleep 2;
 
-  eval { $c = new Convert::Binary::C::Cached @config };
+  eval { $c = Convert::Binary::C::Cached->new( @config ) };
   ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
   eval {
@@ -208,7 +214,7 @@ for( qw( tests/cache/sub/dir tests/cache/header tests/cache/cache ) ) {
 
   ok( compare( $r, $c ) );
 
-  eval { $c = new Convert::Binary::C::Cached @config };
+  eval { $c = Convert::Binary::C::Cached->new( @config ) };
   ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
   eval {
@@ -226,7 +232,7 @@ for( qw( tests/cache/sub/dir tests/cache/header tests/cache/cache ) ) {
 
 # changing the way we're parsing should trigger re-parsing
 
-eval { $c = new Convert::Binary::C::Cached @config };
+eval { $c = Convert::Binary::C::Cached->new( @config ) };
 ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
 eval {
@@ -244,7 +250,7 @@ ok( $c->__uses_cache, 0, "object is using cache file" );
 
 ok( compare( $r, $c ) );
 
-eval { $c = new Convert::Binary::C::Cached @config };
+eval { $c = Convert::Binary::C::Cached->new( @config ) };
 ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
 eval {
@@ -263,7 +269,7 @@ ok( compare( $r, $c ) );
 
 # changing the embedded code should trigger re-parsing
 
-eval { $c = new Convert::Binary::C::Cached @config };
+eval { $c = Convert::Binary::C::Cached->new( @config ) };
 ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
 eval {
@@ -283,7 +289,7 @@ ok( $c->__uses_cache, 0, "object is using cache file" );
 
 ok( compare( $r, $c ) );
 
-eval { $c = new Convert::Binary::C::Cached @config };
+eval { $c = Convert::Binary::C::Cached->new( @config ) };
 ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
 eval {
@@ -305,7 +311,7 @@ ok( compare( $r, $c ) );
 
 push @config, Define => ['BAR'];
 
-eval { $c = new Convert::Binary::C::Cached @config };
+eval { $c = Convert::Binary::C::Cached->new( @config ) };
 ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
 eval {
@@ -325,7 +331,7 @@ ok( $c->__uses_cache, 0, "object is using cache file" );
 
 ok( compare( $r, $c ) );
 
-eval { $c = new Convert::Binary::C::Cached @config };
+eval { $c = Convert::Binary::C::Cached->new( @config ) };
 ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
 eval {
@@ -351,7 +357,7 @@ cleanup();
 # check cache file corruption
 
 $code = 'typedef int foo;';
-eval { $c = new Convert::Binary::C::Cached Cache => $cache };
+eval { $c = Convert::Binary::C::Cached->new( Cache => $cache ) };
 ok($@,'',"failed to create Convert::Binary::C::Cached object");
 
 eval { $c->parse( $code ) };
@@ -381,7 +387,7 @@ for( $pos = 0; $pos < $size; $pos++ ) {
   {
     local $SIG{__WARN__} = sub { push @warn, $_[0] };
 
-    eval { $c = new Convert::Binary::C::Cached Cache => $cache };
+    eval { $c = Convert::Binary::C::Cached->new( Cache => $cache ) };
     if( $@ ne '' ) {
       $@ =~ s/^/# /gm;
       print "# failed to create Convert::Binary::C::Cached object\n$@";

--- a/tests/215_local.t
+++ b/tests/215_local.t
@@ -18,7 +18,7 @@ BEGIN {
 my $CCCFG = require 'tests/include/config.pl';
 
 eval {
-  $c = new Convert::Binary::C;
+  $c = Convert::Binary::C->new;
 };
 ok($@,'',"failed to create Convert::Binary::C::Cached object");
 

--- a/tests/216_language.t
+++ b/tests/216_language.t
@@ -14,7 +14,7 @@ $^W = 1;
 BEGIN { plan tests => 43 }
 
 eval {
-  $c = new Convert::Binary::C;
+  $c = Convert::Binary::C->new;
 };
 ok($@,'',"failed to create Convert::Binary::C object");
 

--- a/tests/219_def.t
+++ b/tests/219_def.t
@@ -18,7 +18,7 @@ BEGIN {
 $SIG{__WARN__} = sub { push @warn, $_[0] };
 
 eval {
-  $c = new Convert::Binary::C;
+  $c = Convert::Binary::C->new;
 };
 ok($@,'',"failed to create Convert::Binary::C object");
 

--- a/tests/220_new.t
+++ b/tests/220_new.t
@@ -17,11 +17,11 @@ BEGIN {
 
 # This test is basically only for the 901_memory.t test
 
-$c = eval { new Convert::Binary::C };
+$c = eval { Convert::Binary::C->new };
 ok( $@, '' );
 
-$c = eval { new Convert::Binary::C 'foo' };
+$c = eval { Convert::Binary::C->new( 'foo' ) };
 ok( $@, qr/^Number of configuration arguments to new must be even/ );
 
-$c = eval { new Convert::Binary::C foo => 42 };
+$c = eval { Convert::Binary::C->new( foo => 42 ) };
 ok( $@, qr/^Invalid option 'foo'/ );

--- a/tests/221_asm.t
+++ b/tests/221_asm.t
@@ -16,12 +16,13 @@ BEGIN {
 }
 
 my $c = eval {
-          new Convert::Binary::C
-          KeywordMap => { __asm__ => 'asm', __volatile__ => 'volatile' }
-        };
+  Convert::Binary::C->new(
+    KeywordMap => { __asm__ => 'asm', __volatile__ => 'volatile' }
+  );
+};
 ok($@,'');
 
-my $d = eval { new Convert::Binary::C DisabledKeywords => [ 'asm' ] };
+my $d = eval { Convert::Binary::C->new( DisabledKeywords => [ 'asm' ] ) };
 ok($@,'');
 
 for my $code ( do { local $/; split /-{20,}\r?\n?/, <DATA> } ) {

--- a/tests/222_ieee.t
+++ b/tests/222_ieee.t
@@ -19,7 +19,7 @@ $reason = Convert::Binary::C::feature('ieeefp') ? '' : 'no IEEE floating point';
 
 $SIG{__WARN__} = sub { push @warn, $_[0] };
 
-my $c = eval { new Convert::Binary::C };
+my $c = eval { Convert::Binary::C->new };
 skip($reason,$@,'');
 
 # check with reference data

--- a/tests/223_initializer.t
+++ b/tests/223_initializer.t
@@ -15,7 +15,7 @@ BEGIN { plan tests => 27 }
 
 my $CCCFG = require 'tests/include/config.pl';
 
-$c = eval { new Convert::Binary::C %$CCCFG };
+$c = eval { Convert::Binary::C->new( %$CCCFG ) };
 ok($@,'',"failed to create Convert::Binary::C objects");
 
 eval { $c->parse_file( 'tests/include/include.c' ) };
@@ -32,7 +32,7 @@ for( $c->typedef_names ) {
   $full .= $pre . $c->initializer( $_, $init ) . $post;
 }
 
-$c = eval { new Convert::Binary::C };
+$c = eval { Convert::Binary::C->new };
 ok($@,'',"failed to create Convert::Binary::C objects");
 
 {

--- a/tests/224_typeof.t
+++ b/tests/224_typeof.t
@@ -17,7 +17,7 @@ BEGIN { plan tests => 31 }
 @tests = map { chomp; /^\s*(.*?)\s*=>\s*(.*?)\s*$/ ? { name => $1, type => $2 } : () }
          split $/, $tests;
 
-$c = eval { new Convert::Binary::C };
+$c = eval { Convert::Binary::C->new };
 ok($@,'',"failed to create Convert::Binary::C object");
 
 eval { $c->parse( $code ) };

--- a/tests/226_indexed.t
+++ b/tests/226_indexed.t
@@ -16,7 +16,7 @@ BEGIN { plan tests => 45 }
 my $reason = do {
   my @w;
   local $SIG{__WARN__} = sub { push @w, @_ };
-  my $c = new Convert::Binary::C OrderMembers => 1;
+  my $c = Convert::Binary::C->new( OrderMembers => 1 );
   (grep /Couldn't load a module for member ordering/, @w)
   ? "member ordering requires indexed hashes" : "";
 };
@@ -26,8 +26,8 @@ my $order = $reason ? 0 : 1;
 my @keys = grep !/do|if/, 'aa' .. 'zz';
 my $members = join "\n", map "unsigned char $_;", @keys;
 
-my $u = new Convert::Binary::C OrderMembers => 0;
-my $o = new Convert::Binary::C OrderMembers => $order;
+my $u = Convert::Binary::C->new( OrderMembers => 0 );
+my $o = Convert::Binary::C->new( OrderMembers => $order );
 
 for my $c ( $u, $o ) {
   $c->parse( <<ENDC );

--- a/tests/227_flexarray.t
+++ b/tests/227_flexarray.t
@@ -13,7 +13,7 @@ $^W = 1;
 
 BEGIN { plan tests => 49 }
 
-my $c = new Convert::Binary::C IntSize => 4, ShortSize => 2, Alignment => 4;
+my $c = Convert::Binary::C->new( IntSize => 4, ShortSize => 2, Alignment => 4 );
 
 $c->parse(<<ENDC);
 

--- a/tests/228_hooks.t
+++ b/tests/228_hooks.t
@@ -20,11 +20,13 @@ unless ($reason) {
   $reason = 'cannot use dualvar()' if $@;
 }
 
-my $c = new Convert::Binary::C ByteOrder   => 'BigEndian',
-                               EnumType    => 'String',
-                               EnumSize    => 4,
-                               IntSize     => 4,
-                               PointerSize => 4;
+my $c = Convert::Binary::C->new(
+  ByteOrder   => 'BigEndian',
+  EnumType    => 'String',
+  EnumSize    => 4,
+  IntSize     => 4,
+  PointerSize => 4
+);
 
 $c->parse(<<'ENDC');
 

--- a/tests/229_substr.t
+++ b/tests/229_substr.t
@@ -34,7 +34,7 @@ sub chkwarn {
   @warn = ();
 }
 
-$c = new Convert::Binary::C ByteOrder => 'BigEndian', IntSize => 4;
+$c = Convert::Binary::C->new( ByteOrder => 'BigEndian', IntSize => 4 );
 $c->parse("typedef unsigned int u_32;");
 
 $ref  = pack "N*", 1000000, 5000000, 3000000, 4000000;

--- a/tests/230_compiler.t
+++ b/tests/230_compiler.t
@@ -39,7 +39,7 @@ for my $cur (sort keys %cc) {
 
   do $cc{$cur}{cfg};
 
-  my $c = new Convert::Binary::C %config;
+  my $c = Convert::Binary::C->new( %config );
   $c->parse_file('tests/compiler/test.h');
   my $pck = $c->pack('test', $dat);
 

--- a/tests/231_align.t
+++ b/tests/231_align.t
@@ -13,9 +13,7 @@ $^W = 1;
 
 BEGIN { plan tests => 212 }
 
-$c = new Convert::Binary::C ShortSize => 2
-                          , LongSize  => 4
-                          ;
+$c = Convert::Binary::C->new( ShortSize => 2, LongSize  => 4 );
 
 eval { $c->parse(<<ENDC) };
 

--- a/tests/232_native.t
+++ b/tests/232_native.t
@@ -30,7 +30,7 @@ eval {
 };
 ok($@, qr/^Invalid property 'EnumType'/);
 
-$c = new Convert::Binary::C;
+$c = Convert::Binary::C->new;
 eval {
   $s2 = $c->native('IntSize');
 };

--- a/tests/233_tags.t
+++ b/tests/233_tags.t
@@ -13,7 +13,7 @@ $^W = 1;
 
 BEGIN { plan tests => 148 }
 
-my $c = new Convert::Binary::C;
+my $c = Convert::Binary::C->new;
 
 eval {
   $c->parse(<<ENDC);

--- a/tests/234_format.t
+++ b/tests/234_format.t
@@ -15,8 +15,12 @@ BEGIN { plan tests => 148 }
 
 # TODO: different alignments
 
-my $c = new Convert::Binary::C ByteOrder => 'LittleEndian',
-                               IntSize => 4, CharSize => 1, EnumSize => 4;
+my $c = Convert::Binary::C->new(
+  ByteOrder => 'LittleEndian',
+  IntSize   => 4,
+  CharSize  => 1,
+  EnumSize  => 4
+);
 
 eval {
   $c->parse(<<ENDC);

--- a/tests/235_basic.t
+++ b/tests/235_basic.t
@@ -13,7 +13,7 @@ $^W = 1;
 
 BEGIN { plan tests => 54 }
 
-my $c = new Convert::Binary::C;
+my $c = Convert::Binary::C->new;
 
 for my $t ( 'char'
           , 'signed char'

--- a/tests/236_typeinfo.t
+++ b/tests/236_typeinfo.t
@@ -13,7 +13,7 @@ $^W = 1;
 
 BEGIN { plan tests => 49 }
 
-my $c = new Convert::Binary::C;
+my $c = Convert::Binary::C->new;
 
 $c->parse(<<ENDC);
 

--- a/tests/237_parser.t
+++ b/tests/237_parser.t
@@ -13,7 +13,7 @@ $^W = 1;
 
 BEGIN { plan tests => 18 }
 
-my $c = eval { new Convert::Binary::C };
+my $c = eval { Convert::Binary::C->new };
 ok($@,'',"failed to create Convert::Binary::C object");
 
 $c->PointerSize(4)->IntSize(2)->CharSize(1);

--- a/tests/238_byteorder.t
+++ b/tests/238_byteorder.t
@@ -9,8 +9,11 @@
 use Test::More tests => 32;
 use Convert::Binary::C @ARGV;
 
-my $c = new Convert::Binary::C ByteOrder => 'LittleEndian',
-                               IntSize => 4, EnumSize => 4;
+my $c = Convert::Binary::C->new(
+  ByteOrder => 'LittleEndian',
+  IntSize   => 4,
+  EnumSize  => 4
+);
 
 eval {
   $c->parse(<<ENDC);

--- a/tests/239_macros.t
+++ b/tests/239_macros.t
@@ -12,7 +12,7 @@ use Convert::Binary::C @ARGV;
 my @stdname = qw( __STDC_HOSTED__ __STDC_VERSION__ );
 my @stddef  = qw( __STDC_HOSTED__=1 __STDC_VERSION__=199901L );
 
-my $c = new Convert::Binary::C;
+my $c = Convert::Binary::C->new;
 
 eval {
   $c->parse('');

--- a/tests/240_offsetof.t
+++ b/tests/240_offsetof.t
@@ -9,7 +9,7 @@
 use Test::More tests => 377;
 use Convert::Binary::C @ARGV;
 
-my $c = new Convert::Binary::C IntSize => 4, CharSize => 1, Alignment => 1;
+my $c = Convert::Binary::C->new( IntSize => 4, CharSize => 1, Alignment => 1 );
 
 eval {
 $c->parse(<<'ENDC');

--- a/tests/241_sizeof.t
+++ b/tests/241_sizeof.t
@@ -9,7 +9,7 @@
 use Test::More tests => 71;
 use Convert::Binary::C @ARGV;
 
-my $c = new Convert::Binary::C IntSize => 4, CharSize => 1, Alignment => 1;
+my $c = Convert::Binary::C->new( IntSize => 4, CharSize => 1, Alignment => 1 );
 
 eval {
 $c->parse(<<'ENDC');

--- a/tests/242_dimension.t
+++ b/tests/242_dimension.t
@@ -12,11 +12,13 @@ use strict;
 
 $^W = 1;
 
-my $c = new Convert::Binary::C CharSize  => 1
-                             , ShortSize => 2
-                             , IntSize   => 4
-                             , Alignment => 1
-                             , ByteOrder => 'BigEndian';
+my $c = Convert::Binary::C->new(
+  CharSize  => 1,
+  ShortSize => 2,
+  IntSize   => 4,
+  Alignment => 1,
+  ByteOrder => 'BigEndian'
+);
 
 $c->parse(<<'ENDC');
 

--- a/tests/243_parser.t
+++ b/tests/243_parser.t
@@ -12,7 +12,7 @@ use strict;
 
 $^W = 1;
 
-my $c = new Convert::Binary::C;
+my $c = Convert::Binary::C->new;
 
 eval { $c->parse_file('tests/parser/context.c') };
 

--- a/tests/501_bfsimple.t
+++ b/tests/501_bfsimple.t
@@ -14,8 +14,13 @@ $^W = 1;
 
 my $BIN = $] < 5.006 ? '%x' : '%08b';
 
-my $c = eval { new Convert::Binary::C Bitfields => { Engine => 'Simple', BlockSize => 4 },
-                                      EnumType  => 'String' };
+my $c = eval {
+  Convert::Binary::C->new(
+    Bitfields => { Engine => 'Simple', BlockSize => 4 },
+    EnumType  => 'String'
+  );
+};
+
 is($@, '', "failed to create Convert::Binary::C object");
 
 eval { $c->parse(<<ENDC) };

--- a/tests/601_speed.t
+++ b/tests/601_speed.t
@@ -66,7 +66,7 @@ $start_time = mytime();
 $fail = 0;
 do {
   eval {
-    $c = new Convert::Binary::C %$CCCFG;
+    $c = Convert::Binary::C->new( %$CCCFG );
     $c->parse_file( 'tests/include/include.c' );
   };
   $@ and $fail = 1 and last;
@@ -89,7 +89,7 @@ print "# uncached: $iterations iterations in $elapsed_time seconds\n";
 
 # create cache file
 eval {
-  $c = new Convert::Binary::C::Cached Cache => $cache, %$CCCFG;
+  $c = Convert::Binary::C::Cached->new( Cache => $cache, %$CCCFG );
 
   $c->parse_file( 'tests/include/include.c' );
 };
@@ -102,7 +102,7 @@ ok( -e $cache );
 $start_time = mytime();
 eval {
   for( 1 .. $iterations ) {
-    $c = new Convert::Binary::C::Cached Cache => $cache, %$CCCFG;
+    $c = Convert::Binary::C::Cached->new( Cache => $cache, %$CCCFG );
     $c->parse_file( 'tests/include/include.c' );
   }
 };

--- a/tests/602_threads.t
+++ b/tests/602_threads.t
@@ -35,11 +35,11 @@ my @t;
 if ($have_threads) {
   if ($Config{use5005threads}) {
     require Thread;
-    @t = map { new Thread \&task, $_ } 1 .. NUM_THREADS;
+    @t = map { Thread->new( \&task, $_ ) } 1 .. NUM_THREADS;
   }
   elsif ($Config{useithreads} && $] >= 5.008) {
     require threads;
-    @t = map { new threads \&task, $_ } 1 .. NUM_THREADS;
+    @t = map { threads->new( \&task, $_ ) } 1 .. NUM_THREADS;
   }
 }
 else {
@@ -56,16 +56,18 @@ sub task
   my $p;
 
   eval {
-    $p = new Convert::Binary::C %$CCCFG,
-                                EnumSize       => 0,
-                                ShortSize      => 2,
-                                IntSize        => 4,
-                                LongSize       => 4,
-                                LongLongSize   => 8,
-                                PointerSize    => 4,
-                                FloatSize      => 4,
-                                DoubleSize     => 8,
-                                LongDoubleSize => 12;
+    $p = Convert::Binary::C->new(
+      %$CCCFG,
+      EnumSize       => 0,
+      ShortSize      => 2,
+      IntSize        => 4,
+      LongSize       => 4,
+      LongLongSize   => 8,
+      PointerSize    => 4,
+      FloatSize      => 4,
+      DoubleSize     => 8,
+      LongDoubleSize => 12
+    );
     if ($arg % 2) {
       print "# parse_file ($arg) called\n";
       $p->parse_file('tests/include/include.c');

--- a/tests/603_complex.t
+++ b/tests/603_complex.t
@@ -3013,14 +3013,16 @@ sub checkrc
   }
 }
 
-my $p = new Convert::Binary::C ByteOrder   => 'LittleEndian',
-                               ShortSize   => 2,
-                               IntSize     => 4,
-                               LongSize    => 4,
-                               PointerSize => 4,
-                               FloatSize   => 4,
-                               DoubleSize  => 8,
-                               Alignment   => 4;
+my $p = Convert::Binary::C->new(
+  ByteOrder   => 'LittleEndian',
+  ShortSize   => 2,
+  IntSize     => 4,
+  LongSize    => 4,
+  PointerSize => 4,
+  FloatSize   => 4,
+  DoubleSize  => 8,
+  Alignment   => 4
+);
 
 $p->parse($types);
 

--- a/tests/701_debug.t
+++ b/tests/701_debug.t
@@ -41,7 +41,7 @@ else {
 ok( -e $dbfile xor not $debug );
 ok( -z $dbfile xor not $debug );
 
-eval { $p = new Convert::Binary::C };
+eval { $p = Convert::Binary::C->new };
 
 ok( $@, '' );
 ok( ref $p, 'Convert::Binary::C' );

--- a/tests/702_env.t
+++ b/tests/702_env.t
@@ -49,7 +49,7 @@ chkwarn();
 @w= ( qr/^Convert::Binary::C parser is DISABLED/ );
 $ixhash or push @w, qr/^Couldn't load a module for member ordering/;
 
-$c = eval { new Convert::Binary::C };
+$c = eval { Convert::Binary::C->new };
 ok( $@, '', "could not create Convert::Binary::C object" );
 chkwarn( @w );
 ok( $c->OrderMembers, 1 );
@@ -59,7 +59,7 @@ chkwarn();
 ok( $c->OrderMembers, 0 );
 chkwarn();
 
-$c = eval { new Convert::Binary::C OrderMembers => 0 };
+$c = eval { Convert::Binary::C->new( OrderMembers => 0 ) };
 ok( $@, '', "could not create Convert::Binary::C object" );
 chkwarn( $w[0] );
 ok( $c->OrderMembers, 0 );


### PR DESCRIPTION
The last PR didn't include the tests when the indirect object notation was removed.

This is my entry for the Pull Request Challenge 2017.