### PR TITLE
Fix tests for Perl 5.26

### DIFF
--- a/bin/perltypes.PL
+++ b/bin/perltypes.PL
@@ -21,10 +21,11 @@ print OUT <<'!NO!SUBS!';
 
 use Convert::Binary::C;
 use Data::Dumper;
+use File::Spec::Functions qw(rel2abs);
 use strict;
 
 my $base;
--d "$_/include" and $base = "$_/include" and last for qw( tests ../tests );
+-d "$_/include" and $base = rel2abs("$_/include") and last for qw( tests ../tests );
 defined $base or die <<MSG;
 Please run this script from either the 'examples' directory
 or the distribution base directory.

--- a/tests/206_parse.t
+++ b/tests/206_parse.t
@@ -13,7 +13,7 @@ $^W = 1;
 
 BEGIN { plan tests => 116 }
 
-my $CCCFG = require 'tests/include/config.pl';
+my $CCCFG = require './tests/include/config.pl';
 
 #===================================================================
 # create object (1 tests)
@@ -140,7 +140,7 @@ ok($s1,329,"incorrect number of typedef identifiers");
 # check if all sizes are correct (1 big test)
 #===================================================================
 
-do 'tests/include/sizeof.pl';
+do './tests/include/sizeof.pl';
 $max_size = 0;
 @fail = ();
 @success = ();

--- a/tests/209_sourcify.t
+++ b/tests/209_sourcify.t
@@ -13,7 +13,7 @@ $^W = 1;
 
 BEGIN { plan tests => 98 }
 
-my $CCCFG = require 'tests/include/config.pl';
+my $CCCFG = require './tests/include/config.pl';
 
 eval {
   $orig  = new Convert::Binary::C %$CCCFG;

--- a/tests/210_depend.t
+++ b/tests/210_depend.t
@@ -13,7 +13,7 @@ $^W = 1;
 
 BEGIN { plan tests => 483 }
 
-my $CCCFG = require 'tests/include/config.pl';
+my $CCCFG = require './tests/include/config.pl';
 
 eval {
   $c1 = new Convert::Binary::C Include => ['tests/include/files'];

--- a/tests/211_clone.t
+++ b/tests/211_clone.t
@@ -13,7 +13,7 @@ $^W = 1;
 
 BEGIN { plan tests => 35 }
 
-my $CCCFG = require 'tests/include/config.pl';
+my $CCCFG = require './tests/include/config.pl';
 
 eval {
   $orig = new Convert::Binary::C %$CCCFG;

--- a/tests/215_local.t
+++ b/tests/215_local.t
@@ -15,7 +15,7 @@ BEGIN {
   plan tests => 10;
 }
 
-my $CCCFG = require 'tests/include/config.pl';
+my $CCCFG = require './tests/include/config.pl';
 
 eval {
   $c = new Convert::Binary::C;

--- a/tests/218_member.t
+++ b/tests/218_member.t
@@ -15,7 +15,7 @@ BEGIN {
   plan tests => 1907;
 }
 
-my $CCCFG = require 'tests/include/config.pl';
+my $CCCFG = require './tests/include/config.pl';
 
 %basic = ( char => 1, short => 1, int => 1,
            long => 1, signed => 1, unsigned => 1,

--- a/tests/223_initializer.t
+++ b/tests/223_initializer.t
@@ -13,7 +13,7 @@ $^W = 1;
 
 BEGIN { plan tests => 27 }
 
-my $CCCFG = require 'tests/include/config.pl';
+my $CCCFG = require './tests/include/config.pl';
 
 $c = eval { new Convert::Binary::C %$CCCFG };
 ok($@,'',"failed to create Convert::Binary::C objects");

--- a/tests/230_compiler.t
+++ b/tests/230_compiler.t
@@ -37,7 +37,7 @@ for my $cur (sort keys %cc) {
   $bin =~ s/\s+//gms;
   $bin = pack "H*", $bin;
 
-  do $cc{$cur}{cfg};
+  do "./$cc{$cur}{cfg}";
 
   my $c = new Convert::Binary::C %config;
   $c->parse_file('tests/compiler/test.h');

--- a/tests/601_speed.t
+++ b/tests/601_speed.t
@@ -16,7 +16,7 @@ BEGIN {
   plan tests => 11;
 }
 
-my $CCCFG = require 'tests/include/config.pl';
+my $CCCFG = require './tests/include/config.pl';
 
 eval { require Data::Dumper }; $Data_Dumper = $@;
 eval { require IO::File };     $IO_File = $@;

--- a/tests/602_threads.t
+++ b/tests/602_threads.t
@@ -17,7 +17,7 @@ BEGIN {
   plan tests => NUM_THREADS
 }
 
-my $CCCFG = require 'tests/include/config.pl';
+my $CCCFG = require './tests/include/config.pl';
 
 #===================================================================
 # load appropriate threads module and start a couple of threads


### PR DESCRIPTION
NB: There may be other issues I haven't fixed due to not spotting them.

Make sure to run tests with 

PERL_USE_UNSAFE_INC=0 on Perl 5.26

Bug: https://rt.cpan.org/Public/Bug/Display.html?id=121039
Bug: https://bugs.gentoo.org/615106

Reading Material:
- http://blogs.perl.org/users/ryan_voots/2017/04/trials-and-troubles-with-changing-inc.html
- https://wiki.gentoo.org/wiki/Project:Perl/Dot-In-INC-Removal
- https://metacpan.org/pod/release/XSAWYERX/perl-5.26.0/pod/perldelta.pod#Removal-of-the-current-directory-%28%22.%22%29-from-@INC